### PR TITLE
fix: hide empty pagination links (fixes #262)

### DIFF
--- a/src/overrides.css
+++ b/src/overrides.css
@@ -83,3 +83,7 @@ svg .edgeLabel {
 .nextra-toc> .nextra-scrollbar> ul{
     font-size: small;
 }
+
+main a:not([href]) {
+  display: none;
+}


### PR DESCRIPTION
## Description

This PR fixes issue #262 where empty pagination links appear when external links are in the sidebar.

## Changes
- Added CSS rule to hide anchor tags without href attributes in main content
  
## Fixes
- Resolves #262 - Paginated external links broken

## Testing
- Verified that empty pagination links no longer appear while preserving functional pagination

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Anchor elements without an `href` inside the main content area are now hidden for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->