### PR TITLE
Feat(docs): Added missing Tools link to the  Build Section (resolves #344)

### DIFF
--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -31,6 +31,7 @@ faq-tags: [security]
 ### 🛠️ Build
 Tools to help you build AI applications and iterate faster.
 
+- [Tools](/docs/mcp-tools/tools) \- Core components and functions for agent creation.
 - [Studio](/docs/studio) \- GUI for building and deploying AI applications.
 - [Flows](/docs/flows) \- Build Agents, Process and Automations with custom flows using No Code and Low Code.
 - [Tests](/docs/tests) \- Tools to test and debug your flow and application in development and before Deployments.


### PR DESCRIPTION
Fixes #344
Usability Enhancement: I found the 'Tools' link was only listed under 'Connect' on the live site. To improve navigation and align with the descriptive text, I have added the link [Tools](/docs/mcp-tools/tools) to the 🛠️ Build section. This resolves the user confusion reported in this issue.

Hacktoberfest: This contribution is for Hacktoberfest 2025.