### PR TITLE
Fix some typos in `architecture.mdx`

### DIFF
--- a/pages/docs/architecture.mdx
+++ b/pages/docs/architecture.mdx
@@ -5,8 +5,9 @@ description: How does lamatic works?
 # Architecture
 <Callout>
 Lamatic was designed with redundancy and scalability in mind. The architecture is divided into different layers that work together to provide a seamless experience to the users.
-Its designed such that even if our main system fails, it wont still affect your deployed applications and APIs.
+It is designed such that even if our main system fails, it will not affect your deployed applications and APIs.
 </Callout>
+
 ![img_10.png](./img_10.png)
 
 ## Execution Steps
@@ -19,7 +20,7 @@ These following steps highlight the typical execution of steps involved in build
     ### Connect models
     Add model credentials to your flow.
     ### Deploy the flow on Edge
-    Triggering deployment compiles the  whole  worlfow and deploys it on the edge. This is a locked in state of your project which is isolated from lamatic studio and platform.
+    Triggering deployment compiles the  whole  workflow and deploys it on the edge. This is a locked in state of your project which is isolated from lamatic studio and platform.
     ### Trigger the Flow with GrapgQL  API, widgets or webhooks
     Integrate with method of your choice to trigger the flow.
 </Steps>
@@ -89,6 +90,6 @@ This holds all the code logic that enables the reliable execution of our GraphQL
 Integration with third-party models and APIs.
 
 ## Architecture  Diagram
-We have this interative Miro board that explains the architecture of Lamatic.ai in detail and is continously updated. Please feel free to check it out and drop any comments.
+We have this interactive Miro board that explains the architecture of Lamatic.ai in detail and is continuously updated. Please feel free to check it out and drop any comments.
 
 <iframe width="768" height="432" src="https://miro.com/app/live-embed/uXjVKlDyfYc=/?moveToViewport=-952,-3613,1893,1265&embedId=116751400693" scrolling="no" allow="fullscreen; clipboard-read; clipboard-write" allowFullScreen></iframe>


### PR DESCRIPTION
This PR fixes some typos. Please note that the added newline symbol makes the image displayed properly (on github).

Please consider it as part of
`hacktoberfest`