### PR TITLE
fix: replace incorrect OpenAI icon with appropriate for Feedback button

### DIFF
--- a/components/MainContentWrapper.tsx
+++ b/components/MainContentWrapper.tsx
@@ -4,7 +4,7 @@ import { Button } from "./ui/button";
 import {
   Calendar,
   Mail,
-  MessageSquare,
+  MessageSquareHeart,
   ThumbsDown,
   ThumbsUp,
 } from "lucide-react";
@@ -13,7 +13,6 @@ import { Background } from "./Background";
 import { NotebookBanner } from "./NotebookBanner";
 import { ProductUpdateSignup } from "./productUpdateSignup";
 import { COOKBOOK_ROUTE_MAPPING } from "@/lib/cookbook_route_mapping";
-import IconGithub from "./icons/openai";
 import { TOCFix } from "./TOCFix";
 
 const pathsWithoutFooterWidgets = ["/imprint", "/blog"];
@@ -67,7 +66,7 @@ export const DocsSupport = () => {
         <Button variant="outline" size="sm" asChild>
           <a href="https://product.lamatic.ai/" target="_blank">
             <span>Feedback</span>
-            <IconGithub className="h-4 w-4 ml-3" />
+            <MessageSquareHeart className="h-4 w-4 ml-3" />
           </a>
         </Button>
         <Button variant="outline" size="sm" asChild>


### PR DESCRIPTION
## Fix: Feedback Button Icon

This PR updates the feedback button to use the correct `MessageSquareHeart` icon from Lucide React instead of the OpenAI icon, improving clarity and visual consistency.

- Replaces the OpenAI icon with `MessageSquareHeart` for the feedback button.
- Updates relevant imports and ensures the icon renders as intended.
<img width="660" height="173" alt="Screenshot (2)" src="https://github.com/user-attachments/assets/089d497b-f0a5-4540-8c3d-eef7d90955d9" />

Closes #383.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the icon in the DocsSupport section for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->