### PR TITLE
fix(sidebar): mobile menu now opens on small devices

### DIFF
--- a/src/overrides.css
+++ b/src/overrides.css
@@ -331,9 +331,7 @@ body:has([href*="/templates/"]) main > div {
 
 /* For agentkits detail pages specifically - hide sidebar and TOC */
 html[data-pathname*="/agentkits/"] .nextra-toc,
-html[data-pathname*="/agentkits/"] .nextra-sidebar-container,
-body:has([href*="/agentkits/"]) .nextra-toc,
-body:has([href*="/agentkits/"]) .nextra-sidebar-container {
+html[data-pathname*="/agentkits/"] .nextra-sidebar-container {
   display: none !important;
   width: 0 !important;
   min-width: 0 !important;


### PR DESCRIPTION
## Approach
The mobile hamburger/menu was not opening on docs pages due to a broad CSS selector that was hiding the sidebar globally. 

Fixes #419 

## Changes
- Removed the old `body:has([href*="/agentkits/"])` CSS rule that hid the sidebar globally. 
- Mobile menu now works as expected on all docs pages.

## Screenshots

Mobile docs pages – hamburger menu opens correctly:
<img width="517" height="787" alt="Fixes" src="https://github.com/user-attachments/assets/6eddd7f8-c879-4ec3-abbd-299daa9041aa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **Style**
  * Updated layout on agentkits detail pages to display the table of contents, improving navigation and content discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->