### PR TITLE
Fix Maximum call stack size exceeded error in production due to PostHog initialization (#422)

### DIFF
--- a/pages/_app.mdx
+++ b/pages/_app.mdx
@@ -28,7 +28,8 @@ gtag("config", process.env.NEXT_PUBLIC_GTM_ID);
     }
 
     // Initialize PostHog
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && !window.__posthog_initialized) {
+      window.__posthog_initialized = true;
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
         // Enable debug mode in development
@@ -40,8 +41,12 @@ gtag("config", process.env.NEXT_PUBLIC_GTM_ID);
 
     // Track page views
     const handleRouteChange = (path) => {
-      posthog.capture("$pageview");
-      hsPageView(path);
+      if (!window.__posthog_capturing) {
+        window.__posthog_capturing = true;
+        posthog.capture("$pageview");
+        hsPageView(path);
+        window.__posthog_capturing = false;
+      }
     };
     router.events.on("routeChangeComplete", handleRouteChange);
     return () => {


### PR DESCRIPTION
# Description
This MR fixes the `Maximum call stack size exceeded` error in production caused by PostHog initialization.

## Approach
- Added a flag `window.__posthog_initialized` to ensure PostHog is initialized only once.
- Added a flag `window.__posthog_capturing` to prevent recursive `$pageview` capture.

## Impact
- Fixes the stack overflow error in production.
- Prevents performance issues on pages like [https://lamatic.ai/templates](https://lamatic.ai/templates).

## Issue Fixed
- Fix #422


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate analytics initialization during page loads
  * Fixed duplicate page view event tracking to ensure accurate analytics reporting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->