### PR TITLE
fix(docs): correct Sign Up button redirect to Studio signup

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -47,7 +47,7 @@ const config: DocsThemeConfig = {
     extraContent: (
       <>
         <Button size="xs" asChild className="whitespace-nowrap w-[70px]">
-          <Link href={"https://lamatic.ai"}>Sign Up</Link>
+          <Link href={"https://studio.lamatic.ai/signup"}>Sign Up</Link>
         </Button>
       </>
     ),


### PR DESCRIPTION
### What this PR does
Fixes the "Sign Up" button on the Docs page (https://lamatic.ai/docs) so that it redirects to the correct page: https://studio.lamatic.ai/signup.

### Issue
Currently, clicking the "Sign Up" button redirects to https://lamatic.ai/, which is the landing page.  
This causes confusion for users who want to create an account.

### Steps to verify
1. Open https://lamatic.ai/docs
2. Click on the "Sign Up" button
3. Verify that it now redirects to https://studio.lamatic.ai/signup

### Related Issue
Fixes #426 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Sign Up link in the navbar to direct users to the correct destination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->