### PR TITLE
fix(docs): fix extra clickable space around Product Hunt badges

### DIFF
--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -10,16 +10,16 @@ faq-tags: [security]
 > Lamatic is a collaborative Agentic AI Development Platform that helps cross-functional teams collaboratively develop, monitor, and optimize their GenAI applications.
 
 <div className="inline-flex flex-col gap-2">
-  <a href="https://www.producthunt.com/posts/lamatic-ai?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-lamatic-ai" target="_blank" rel="noopener noreferrer">
+  <a className="inline-block" href="https://www.producthunt.com/posts/lamatic-ai?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_souce=badge-lamatic-ai" target="_blank" rel="noopener noreferrer">
     <img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=574320&theme=light&period=daily" alt="Lamatic.ai - Build AI agents in low-code & deploy on edge | Product Hunt" width="200" height="54" />
   </a>
-  <a href="https://www.producthunt.com/posts/lamatic-ai?embed=true&utm_source=badge-top-post-topic-badge&utm_medium=badge&utm_souce=badge-lamatic-ai" target="_blank" rel="noopener noreferrer">
+  <a className="inline-block" href="https://www.producthunt.com/posts/lamatic-ai?embed=true&utm_source=badge-top-post-topic-badge&utm_medium=badge&utm_souce=badge-lamatic-ai" target="_blank" rel="noopener noreferrer">
     <img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-topic-badge.svg?post_id=574320&theme=light&period=weekly&topic_id=237" alt="Lamatic.ai - Build AI agents in low-code & deploy on edge | Product Hunt" width="200" height="54" />
   </a>
-  <a className="inline-block w-[175px]" href="https://aitools.inc/tools/lamatic-ai?utm_source=embed-badge-lamatic-ai&utm_medium=embed&utm_campaign=embed-badge-featured" target="_blank"rel="noopener noreferrer">
+  <a className="inline-block w-[175px]" href="https://aitools.inc/tools/lamatic-ai?utm_source=embed-badge-lamatic-ai&utm_medium=embed&utm_campaign=embed-badge-featured" target="_blank" rel="noopener noreferrer">
     <img src="https://aitools.inc/tools/lamatic-ai/embeds/v1/featured-badge.svg?theme=light" alt="Lamatic.ai | AI Tools" className="w-full" height="54" />
   </a>
-  <a href="https://aitoptools.com/tool/lamatic-ai/" target="_blank" title="Lamatic.ai" rel="noopener noreferrer">
+  <a className="inline-block" href="https://aitoptools.com/tool/lamatic-ai/" target="_blank" title="Lamatic.ai" rel="noopener noreferrer">
     <img src="https://aitoptools.com/wp-content/uploads/2024/01/promote-embed.png" alt="Lamatic.ai" width="200" height="54" />
   </a>
 </div>


### PR DESCRIPTION
### What this PR does
This PR fixes the extra clickable space around the Product Hunt badges on the Docs page (https://lamatic.ai/docs).  
Previously, whitespace surrounding the badges was clickable, which could lead to unintended clicks.

### Issue
See GitHub Issue: #428 

### Fix
- Restricted the clickable area to the image itself using Tailwind classes.

### Steps to verify
1. Open https://lamatic.ai/docs
2. Hover or click around the Product Hunt badges
3. Verify that only the image is clickable and extra whitespace no longer triggers clicks

### Related Issue
Fixes #428 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the badges area on the documentation page into a single, cleaner container for consistent layout.
  * Standardized link attributes to improve security and behavior while preserving all badge images and destinations.
  * Adjusted sizing and spacing for uniform visual alignment and better responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->