### PR TITLE
fix(templates): hide sidebar using Nextra theme config

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -25,6 +25,7 @@
     "title": "Templates",
     "type": "page",
     "theme": {
+      "sidebar": false,
       "layout": "full"
     },
     "display": "hidden"


### PR DESCRIPTION
## Description

This MR fixes the issue where the sidebar was incorrectly visible on the `/templates` page, which caused layout overflow problems.

The root cause was missing page-level theme configuration in `meta.json`. Nextra provides a built-in way to disable the sidebar and enable a full-width layout, but this configuration was not set for the `templates` page.

This change updates `meta.json` to explicitly disable the sidebar and use the full layout for `/templates` pages, removing the need for any CSS or JS workarounds.

## Issue
Fixes #431 

## Changes
- Disabled sidebar for `/templates` page using Nextra `theme.sidebar: false`
- Enabled full-width layout using `theme.layout: "full"`

## Result
- Sidebar are no longer shown on /templates pages
- Content renders in full-width layout as intended
- Uses official Nextra configuration

## Attached SS
<img width="1757" height="921" alt="Fixed" src="https://github.com/user-attachments/assets/cc883a02-1e0e-4125-a05c-8409a2028163" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Templates page layout configuration to explicitly remove the sidebar, ensuring a clean full-width display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->