### PR TITLE
fix(docs): improve table header readability in dark mode

### DIFF
--- a/components/NodeTypeInfo.tsx
+++ b/components/NodeTypeInfo.tsx
@@ -19,7 +19,7 @@ export const NodeTypeInfo: React.FC<NodeTypeInfoProps> = ({
       <div className="overflow-x-auto">
         <table className="w-full border-collapse border border-gray-300">
           <thead>
-            <tr className="bg-gray-50">
+            <tr className="bg-gray-50 dark:bg-neutral-950">
               <th className="border border-gray-300 px-4 py-2 text-left font-medium">Type</th>
               <th className="border border-gray-300 px-4 py-2 text-left font-medium">Description</th>
               <th className="border border-gray-300 px-4 py-2 text-left font-medium">Status</th>


### PR DESCRIPTION
### Summary
Fixes unreadable table headers in dark mode across documentation pages.

### Details
- Added a dark-mode background to the table header row
- Since the table component is shared, this fix applies consistently to multiple docs pages

### Issue
Fixes #445 

### Testing
- Verified in light mode
- Verified in dark mode
- Checked multiple documentation pages using tables

### Attached screenshot

<img width="861" height="273" alt="fixed-table-header" src="https://github.com/user-attachments/assets/213a1169-abeb-43a3-b768-861aa0e85b27" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode support with enhanced table header styling. Table headers now display with optimized background colors when dark mode is enabled, providing better visual contrast and improved consistency across the interface. This delivers a more polished appearance when using the dark theme.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->