### PR TITLE
Docs: Update Docs' TOC scroll

### DIFF
--- a/components/useTOCFix.ts
+++ b/components/useTOCFix.ts
@@ -5,56 +5,120 @@ export function useTOCFix() {
   const router = useRouter();
   const lastPath = useRef<string>('');
   const [isClient, setIsClient] = useState(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
 
-  // Set client flag to prevent hydration mismatch
   useEffect(() => {
     setIsClient(true);
   }, []);
 
   useEffect(() => {
     if (!isClient) return;
-    
+
     const currentPath = router.asPath.split('#')[0];
-    
-    // Only run if the path has actually changed
+
     if (lastPath.current !== currentPath) {
       lastPath.current = currentPath;
-      
-      const fixTOCLinks = () => {
+
+      const setupTOC = () => {
+        cleanupRef.current?.();
+        cleanupRef.current = null;
+
         const tocContainer = document.querySelector('.nextra-toc');
         if (!tocContainer) return;
 
+        // Build heading list first so click handlers can call updateActive
+        const article = document.querySelector('article');
+        if (!article) return;
+
+        const headings = Array.from(
+          article.querySelectorAll('h1, h2, h3, h4, h5, h6')
+        ).filter((h): h is HTMLElement => !!(h as HTMLElement).id);
+
+        const headingIds = headings.map(h => h.id);
+
+        // Build id→link map once to avoid repeated CSS selector queries
+        const linkMap = new Map<string, HTMLAnchorElement>();
+
+        const setActiveHeading = (id: string) => {
+          tocContainer.querySelectorAll('a').forEach(a => a.classList.remove('toc-active'));
+          linkMap.get(id)?.classList.add('toc-active');
+        };
+
+        // scroll-margin-top is 100px; use 120px so sub-pixel positions don't miss
+        const OFFSET = 120;
+
+        const updateActive = () => {
+          if (headingIds.length === 0) return;
+          let activeId = headingIds[0];
+          for (let i = headingIds.length - 1; i >= 0; i--) {
+            const el = document.getElementById(headingIds[i]);
+            if (el && el.getBoundingClientRect().top <= OFFSET) {
+              activeId = headingIds[i];
+              break;
+            }
+          }
+          setActiveHeading(activeId);
+        };
+
+        // Fix TOC link hrefs and add smooth-scroll handlers (only unpatched links)
         const tocLinks = tocContainer.querySelectorAll('a[href^="#"]');
-        
         tocLinks.forEach((link) => {
           const href = link.getAttribute('href');
-          if (href && href.startsWith('#')) {
-            // Remove any existing click listeners
-            const newLink = link.cloneNode(true) as HTMLAnchorElement;
-            link.parentNode?.replaceChild(newLink, link);
-            
-            // Update the href to include the current page path
-            newLink.setAttribute('href', `${currentPath}${href}`);
-            
-            // Add new click handler
-            newLink.addEventListener('click', (e) => {
-              e.preventDefault();
-              const targetId = href.substring(1);
-              const targetElement = document.getElementById(targetId);
-              if (targetElement) {
-                targetElement.scrollIntoView({ 
-                  behavior: 'smooth',
-                  block: 'start'
-                });
-              }
-            });
-          }
+          if (!href?.startsWith('#')) return;
+
+          const newLink = link.cloneNode(true) as HTMLAnchorElement;
+          link.parentNode?.replaceChild(newLink, link);
+          newLink.setAttribute('href', `${currentPath}${href}`);
+
+          const targetId = href.substring(1);
+
+          newLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            const el = document.getElementById(targetId);
+            if (el) {
+              el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              // Smooth scroll doesn't always emit a final scroll event at the
+              // settled position, so force a check after animation completes.
+              setTimeout(updateActive, 600);
+            }
+          });
         });
+
+        // Populate linkMap from all current TOC anchors (works whether links are
+        // already patched to "/page#id" or still raw "#id" on first run)
+        tocContainer.querySelectorAll('a[href*="#"]').forEach((link) => {
+          const href = link.getAttribute('href') ?? '';
+          const id = href.substring(href.lastIndexOf('#') + 1);
+          if (id) linkMap.set(id, link as HTMLAnchorElement);
+        });
+
+        if (headings.length === 0) return;
+
+        let rafId: number | null = null;
+        const onScroll = () => {
+          if (rafId !== null) return;
+          rafId = requestAnimationFrame(() => {
+            updateActive();
+            rafId = null;
+          });
+        };
+
+        window.addEventListener('scroll', onScroll, { passive: true });
+        cleanupRef.current = () => {
+          window.removeEventListener('scroll', onScroll);
+          if (rafId !== null) cancelAnimationFrame(rafId);
+        };
+
+        updateActive();
       };
 
-      // Fix links after a delay to ensure the page is fully rendered
-      setTimeout(fixTOCLinks, 100);
-      setTimeout(fixTOCLinks, 500); // Double-check after a longer delay
+      setTimeout(setupTOC, 100);
+      setTimeout(setupTOC, 500);
     }
+
+    return () => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+    };
   }, [router.asPath, isClient]);
-} 
+}

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -92,7 +92,10 @@ svg .edgeLabel {
   pointer-events: auto !important;
   user-select: text;
   opacity: 0.6;
-  transition: color 0.2s ease;
+  border-left: 2px solid transparent;
+  padding-left: 8px;
+  margin-left: -10px;
+  transition: color 0.2s ease, opacity 0.2s ease, border-color 0.2s ease;
 }
 
 /* Force TOC links to be updated on page change */
@@ -378,4 +381,17 @@ body:has([href*="/agentkits/"]) main {
   --tw-shadow: 0 0 #0000 !important;
   --tw-shadow-colored: 0 0 #0000 !important;
   box-shadow: none !important;
+}
+
+/* Active TOC item — scroll-spy highlight */
+.nextra-toc a.toc-active {
+  opacity: 1 !important;
+  color: hsl(var(--foreground)) !important;
+  font-weight: 600;
+  border-left-color: hsl(var(--foreground)) !important;
+}
+
+html[class~="dark"] .nextra-toc a.toc-active {
+  color: hsl(var(--foreground)) !important;
+  opacity: 1 !important;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

### `components/useTOCFix.ts`
- Refactored TOC hook to track per-route lifecycle with cleanup function
- Introduced `setupTOC` routine that:
  - Collects heading elements (h1–h6) with IDs
  - Patches TOC links with rewritten hrefs including current path
  - Prevents default smooth scrolling, triggers active check after 600ms
  - Adds requestAnimationFrame-throttled scroll listener for active state updates
- Added explicit listener cleanup between fix runs and cleanup on unmount

### `src/overrides.css`
- Added left border highlight effect to TOC links with `border-left: 2px solid transparent` and padding
- Introduced `.toc-active` styling for active TOC items with `font-weight: 600` and colored left border
- Expanded transitions to include `opacity` and `border-color`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->