### PR TITLE
Clean- Add MCP Docs Page

### DIFF
--- a/pages/docs/mcp-tools/_meta.ts
+++ b/pages/docs/mcp-tools/_meta.ts
@@ -6,5 +6,9 @@ export default {
     "tools":{
         "title": "Tools",
         "type": "doc"
+    },
+    "docs-mcp":{
+        "title": "Docs MCP",
+        "type": "doc"
     }
 }

--- a/pages/docs/mcp-tools/docs-mcp.mdx
+++ b/pages/docs/mcp-tools/docs-mcp.mdx
@@ -1,0 +1,183 @@
+---
+title: Docs MCP
+description: Build a Model Context Protocol server that connects any AI assistant to your documentation — powered by a Lamatic flow.
+---
+
+import { Callout, Steps, Tabs } from "nextra/components";
+
+# Docs MCP
+
+The Lamatic Docs MCP is an open-source [Model Context Protocol](https://modelcontextprotocol.io) server that lets any MCP-compatible AI assistant (Claude etc.) query **your documentation** in real time. Point it at any Lamatic flow that accepts a question and returns an answer, and your AI assistant gains instant, grounded access to your docs.
+
+## How it works
+
+1. The assistant calls the `query_docs` tool with a natural-language question.
+2. The MCP server forwards the question to your Lamatic flow via the GraphQL API.
+3. Your flow queries your documentation (via RAG, search, or any retrieval method) and returns an answer.
+4. The assistant uses the answer as context in its response.
+
+Because the MCP server is just a thin bridge to your flow, it works for **any documentation** — internal wikis, API references, product guides, support knowledge bases, and more.
+
+---
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org) 18 or later
+- A Lamatic project with a **question-answering flow** deployed (see below)
+- An MCP-compatible client (Claude Desktop, Cursor, etc.)
+
+---
+
+## Step 1 — Build two flows in Lamatic
+
+You need two flows: one that **ingests** your docs into a vector database, and one that **answers questions** from it. The MCP server only calls the second flow — the ingestion flow runs on its own schedule or on demand.
+
+### Flow A — Ingestion (index your docs)
+
+This flow processes your documentation and stores it in a vector DB so it can be searched later.
+
+1. **Trigger** — Webhook trigger fired when docs change, or a schedule trigger for periodic re-indexing.
+2. **Fetch docs** — Pull your documentation content (e.g. from GitHub, a CMS, or file storage).
+3. **Chunk** — Split the content into smaller pieces (e.g. 1 000 characters with 100-character overlap).
+4. **Embed** — Generate vector embeddings for each chunk.
+5. **Store** — Write the embeddings and text into a [vector database](/docs/context).
+
+<Callout type="info">
+  **Step-by-step guide available** — [RAG-Powered Chatbot with GitHub Docs](https://lamatic.ai/guides/tutorials/github-docs-rag) walks through building this ingestion flow end-to-end: webhook trigger, chunking node, vectorize node, and index node. Follow that guide to get your docs indexed, then come back here for Flow B and the MCP setup.
+</Callout>
+
+Run the ingestion flow whenever your docs change to keep the index up to date.
+
+### Flow B — Query (answers questions via API)
+
+This is the flow the MCP server calls. It must accept a `question` input and return a text answer.
+
+1. **Trigger** — [API / GraphQL trigger](/docs/flows) with a `question` field in the input schema.
+2. **Retrieve** — Vector search against the index built by Flow A, using `question` as the query.
+3. **Generate** — Pass the retrieved chunks and the question to a [Generate Text node](/docs/nodes/ai/generate-text-node) to produce an answer.
+4. **Respond** — Return the generated answer as the flow output.
+
+Once Flow B is working, **deploy it** — the MCP server calls the deployed API endpoint, not the draft.
+
+<Callout type="info">
+  The `LAMATIC_WORKFLOW_ID` you set in the MCP server is the ID of **Flow B** (the query flow), not the ingestion flow.
+</Callout>
+
+---
+
+## Step 2 — Get your credentials
+
+You need four values from Lamatic Studio.
+
+### Endpoint
+
+Your project's GraphQL endpoint. Found in **Studio → Project → API Docs**.
+
+```
+https://<your-project>.lamatic.dev/graphql
+```
+
+### API Key
+
+Found in **Studio → Project → Settings → Keys**. Create a new key if you don't have one yet.
+
+### Project ID
+
+Found in **Studio → Project → Settings**, at the top of the page next to your project name.
+
+### Flow ID
+
+1. Open **Studio → Flows** and select your Q&A flow.
+2. You can get it from **API DOCS** at top right inside your flow.
+
+<Callout type="warning">
+  The flow must be **deployed** before the MCP server can call it.
+</Callout>
+
+---
+
+## Step 3 — Install the MCP server
+
+```bash
+git clone https://github.com/akshatvirmani/Lamatic-MCP-Docs
+cd Lamatic-MCP-Docs
+npm install
+```
+
+Create a `.env` file in the project root:
+
+```env
+LAMATIC_ENDPOINT=https://<your-project>.lamatic.dev/graphql
+LAMATIC_API_KEY=<your-api-key>
+LAMATIC_PROJECT_ID=<your-project-id>
+LAMATIC_WORKFLOW_ID=<your-flow-id>
+```
+
+**Verify the server starts:**
+
+```bash
+node index.js
+```
+
+If all four variables are set, the server starts silently and waits for MCP messages over stdio. If a variable is missing, it prints which ones are absent and exits.
+
+---
+
+## Step 4 — Connect to your AI assistant
+
+<Tabs items={["Claude Desktop"]}>
+  <Tabs.Tab>
+
+Open your Claude Desktop config file:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the server under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "company-docs": {
+      "command": "node",
+      "args": ["/absolute/path/to/Lamatic-MCP-Docs/index.js"],
+      "env": {
+        "LAMATIC_ENDPOINT": "https://<your-project>.lamatic.dev/graphql",
+        "LAMATIC_API_KEY": "<your-api-key>",
+        "LAMATIC_PROJECT_ID": "<your-project-id>",
+        "LAMATIC_WORKFLOW_ID": "<your-flow-id>"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. You should see **company-docs** listed under connected tools.
+
+  </Tabs.Tab>
+</Tabs>
+
+---
+
+## Using the tool
+
+Once connected, ask your assistant any question about your docs. It will automatically call `query_docs` when it needs documentation context.
+
+**Example prompts:**
+
+- *"How do I configure SSO for our product?"*
+- *"What are the rate limits on the API?"*
+- *"Walk me through the onboarding flow for new users."*
+- *"What does error code 4023 mean?"*
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Server exits on start | Missing `.env` variables | Check that all four variables are set |
+| `query_docs` returns an error | Flow not deployed | Deploy the flow in Lamatic Studio |
+| Tool not visible in assistant | Config path wrong | Use the **absolute** path to `index.js` |
+| Authentication error | Wrong API key | Regenerate the key in Studio → Keys |
+| Empty or irrelevant answers | Flow retrieval not tuned | Review your RAG setup and re-index your docs |


### PR DESCRIPTION
Added MCP Docs page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Added MCP Docs metadata**: Updated `pages/docs/mcp-tools/_meta.ts` to register the new "Docs MCP" documentation section
- **Created MCP documentation page** (`pages/docs/mcp-tools/docs-mcp.mdx`):
  - Explains how to use the Lamatic Docs MCP with MCP-compatible AI assistants
  - Details required two-flow architecture (ingestion/indexing flow and deployed Q&A flow)
  - Lists required credentials: GraphQL endpoint, API key, project ID, and workflow ID
  - Includes installation instructions, environment variable setup, and Claude Desktop configuration
  - Provides usage guidance with prompt examples and troubleshooting table covering common issues (startup failures, undeployed flows, configuration errors, authentication issues, and retrieval tuning)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->