### PR TITLE
Add MCP docs (clean)

### DIFF
--- a/components/SidebarCollapse.tsx
+++ b/components/SidebarCollapse.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 
-const STORAGE_KEY = 'sidebar-collapsed-v1';
+// Stores titles of sections the user has expanded.
+// Default state (no entry) = collapsed.
+const STORAGE_KEY = 'sidebar-expanded-v1';
 
 function loadState(): Set<string> {
   try {
@@ -53,7 +55,7 @@ function setup(): boolean {
   }
   if (!topUl) return false;
 
-  const collapsed = loadState();
+  const expanded = loadState();
   const children = Array.from(topUl.children) as HTMLElement[];
 
   // Walk children and bucket them into groups: [separator → items[]]
@@ -80,15 +82,20 @@ function setup(): boolean {
 
   if (groups.length === 0) return false;
 
+  // Sections that are visually styled like collapsible groups (ALL-CAPS) but
+  // should always remain expanded.
+  const NON_COLLAPSIBLE = new Set(['REFERENCES']);
+
   groups.forEach(({ sep, title, items }) => {
     // Only collapse ALL-CAPS section headers (BUILD, DEPLOY, INTEGRATE, MONITOR…)
     // Skip mixed-case separators like "Switcher" which are not section groups.
     if (title !== title.toUpperCase()) return;
+    if (NON_COLLAPSIBLE.has(title)) return;
 
     if (sep.dataset.collapseReady) return;
     sep.dataset.collapseReady = '1';
 
-    const isCollapsed = collapsed.has(title);
+    const isCollapsed = !expanded.has(title);
 
     // Wrap all items in plain <div> containers so we don't disturb
     // Nextra's ul>li CSS selectors on the items themselves.
@@ -112,16 +119,16 @@ function setup(): boolean {
 
     sep.style.cursor = 'pointer';
     sep.addEventListener('click', () => {
-      const nowCollapsed = collapsed.has(title);
-      nowCollapsed ? collapsed.delete(title) : collapsed.add(title);
-      saveState(collapsed);
+      const wasExpanded = expanded.has(title);
+      wasExpanded ? expanded.delete(title) : expanded.add(title);
+      saveState(expanded);
 
-      const next = !nowCollapsed;
+      const nextCollapsed = wasExpanded;
       // Match Nextra's Collapse component: 500ms open, 300ms close, ease-in-out
-      wrapperDiv.style.transition = `grid-template-rows ${next ? '300ms' : '500ms'} cubic-bezier(0.4,0,0.2,1)`;
-      wrapperDiv.style.gridTemplateRows = next ? '0fr' : '1fr';
+      wrapperDiv.style.transition = `grid-template-rows ${nextCollapsed ? '300ms' : '500ms'} cubic-bezier(0.4,0,0.2,1)`;
+      wrapperDiv.style.gridTemplateRows = nextCollapsed ? '0fr' : '1fr';
       const chevron = sep.querySelector('[data-chevron]') as HTMLElement | null;
-      if (chevron) chevron.style.transform = next ? 'rotate(-90deg)' : 'rotate(0deg)';
+      if (chevron) chevron.style.transform = nextCollapsed ? 'rotate(-90deg)' : 'rotate(0deg)';
     });
   });
 

--- a/components/SidebarCollapse.tsx
+++ b/components/SidebarCollapse.tsx
@@ -1,0 +1,146 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+const STORAGE_KEY = 'sidebar-collapsed-v1';
+
+function loadState(): Set<string> {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return v ? new Set(JSON.parse(v)) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function saveState(s: Set<string>) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...s]));
+  } catch {}
+}
+
+function buildChevron(collapsed: boolean): SVGSVGElement {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', '10');
+  svg.setAttribute('height', '10');
+  svg.setAttribute('viewBox', '0 0 10 10');
+  svg.setAttribute('fill', 'currentColor');
+  svg.setAttribute('data-chevron', '1');
+  svg.style.cssText = `flex-shrink:0;opacity:0.5;transition:transform 0.2s ease;transform:${collapsed ? 'rotate(-90deg)' : 'rotate(0deg)'}`;
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', 'M5 7L0 2h10L5 7z');
+  svg.appendChild(path);
+  return svg;
+}
+
+function setup(): boolean {
+  // Use the same approach as SidebarSwitcher: query all <li> in the sidebar
+  const allLi = Array.from(
+    document.querySelectorAll('.nextra-sidebar-container li')
+  ) as HTMLElement[];
+
+  if (allLi.length === 0) return false;
+
+  // Find the top-level <ul> by locating the first separator.
+  // A separator <li> has NO <a> or <button> descendant and has non-empty text.
+  let topUl: HTMLElement | null = null;
+  for (const li of allLi) {
+    const hasInteractive = li.querySelector('a, button');
+    const text = li.textContent?.trim();
+    if (!hasInteractive && text && li.parentElement?.tagName === 'UL') {
+      topUl = li.parentElement as HTMLElement;
+      break;
+    }
+  }
+  if (!topUl) return false;
+
+  const collapsed = loadState();
+  const children = Array.from(topUl.children) as HTMLElement[];
+
+  // Walk children and bucket them into groups: [separator → items[]]
+  const groups: { sep: HTMLElement; title: string; items: HTMLElement[] }[] = [];
+  let sep: HTMLElement | null = null;
+  let title = '';
+  let items: HTMLElement[] = [];
+
+  for (const li of children) {
+    const hasInteractive = li.querySelector('a, button');
+    const text = li.textContent?.trim();
+    const isSep = !hasInteractive && !!text;
+
+    if (isSep) {
+      if (sep && items.length) groups.push({ sep, title, items });
+      sep = li;
+      title = text!;
+      items = [];
+    } else if (sep) {
+      items.push(li);
+    }
+  }
+  if (sep && items.length) groups.push({ sep, title, items });
+
+  if (groups.length === 0) return false;
+
+  groups.forEach(({ sep, title, items }) => {
+    // Only collapse ALL-CAPS section headers (BUILD, DEPLOY, INTEGRATE, MONITOR…)
+    // Skip mixed-case separators like "Switcher" which are not section groups.
+    if (title !== title.toUpperCase()) return;
+
+    if (sep.dataset.collapseReady) return;
+    sep.dataset.collapseReady = '1';
+
+    const isCollapsed = collapsed.has(title);
+
+    // Wrap all items in plain <div> containers so we don't disturb
+    // Nextra's ul>li CSS selectors on the items themselves.
+    const wrapperDiv = document.createElement('div');
+    wrapperDiv.style.cssText =
+      'display:grid;overflow:hidden;';
+    wrapperDiv.style.gridTemplateRows = isCollapsed ? '0fr' : '1fr';
+
+    const innerDiv = document.createElement('div');
+    innerDiv.style.minHeight = '0'; // required for grid 0fr to fully collapse
+    items.forEach(li => innerDiv.appendChild(li));
+    wrapperDiv.appendChild(innerDiv);
+    sep.after(wrapperDiv);
+
+    // Add chevron into the separator's first child element (or the li itself)
+    const textEl = (sep.firstElementChild ?? sep) as HTMLElement;
+    if (!sep.querySelector('[data-chevron]')) {
+      textEl.style.cssText += ';display:flex;align-items:center;justify-content:space-between;';
+      textEl.appendChild(buildChevron(isCollapsed));
+    }
+
+    sep.style.cursor = 'pointer';
+    sep.addEventListener('click', () => {
+      const nowCollapsed = collapsed.has(title);
+      nowCollapsed ? collapsed.delete(title) : collapsed.add(title);
+      saveState(collapsed);
+
+      const next = !nowCollapsed;
+      // Match Nextra's Collapse component: 500ms open, 300ms close, ease-in-out
+      wrapperDiv.style.transition = `grid-template-rows ${next ? '300ms' : '500ms'} cubic-bezier(0.4,0,0.2,1)`;
+      wrapperDiv.style.gridTemplateRows = next ? '0fr' : '1fr';
+      const chevron = sep.querySelector('[data-chevron]') as HTMLElement | null;
+      if (chevron) chevron.style.transform = next ? 'rotate(-90deg)' : 'rotate(0deg)';
+    });
+  });
+
+  return true;
+}
+
+export function SidebarCollapse() {
+  const router = useRouter();
+
+  useEffect(() => {
+    // Try immediately, then fall back to MutationObserver if sidebar not rendered yet
+    if (setup()) return;
+
+    const observer = new MutationObserver(() => {
+      if (setup()) observer.disconnect();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [router.asPath]);
+
+  return null;
+}

--- a/components/SidebarCollapse.tsx
+++ b/components/SidebarCollapse.tsx
@@ -84,7 +84,7 @@ function setup(): boolean {
 
   // Sections that are visually styled like collapsible groups (ALL-CAPS) but
   // should always remain expanded.
-  const NON_COLLAPSIBLE = new Set(['REFERENCES']);
+  const NON_COLLAPSIBLE = new Set(['MORE']);
 
   groups.forEach(({ sep, title, items }) => {
     // Only collapse ALL-CAPS section headers (BUILD, DEPLOY, INTEGRATE, MONITOR…)

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,6 +11,7 @@ import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import ChatbotScript from "@/components/ChatbotScript";
 import { SidebarSwitcher } from "@/components/SidebarSwitcher";
+import { SidebarCollapse } from "@/components/SidebarCollapse";
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
@@ -72,6 +73,7 @@ export default function App({ Component, pageProps }: AppProps) {
           ></iframe>
         </noscript>
         <Component {...pageProps} />
+        <SidebarCollapse />
         <SidebarSwitcher />
         <ChatbotScript />
       </PostHogProvider>

--- a/pages/docs/_meta.ts
+++ b/pages/docs/_meta.ts
@@ -73,6 +73,10 @@ export default {
     title: "MCP/Tools",
     type: "doc",
   },
+  "docs-mcp": {
+    title: "Docs MCP",
+    type: "doc",
+  },
   tests: {
     title: "Test",
     type: "doc",

--- a/pages/docs/_meta.ts
+++ b/pages/docs/_meta.ts
@@ -158,9 +158,9 @@ export default {
     title: "Feedback API",
     type: "doc",
   },
-  "REFERENCES": {
+  "MORE": {
     type: "separator",
-    title: "REFERENCES",
+    title: "MORE",
   },
 
   "docs-mcp": {

--- a/pages/docs/_meta.ts
+++ b/pages/docs/_meta.ts
@@ -73,10 +73,6 @@ export default {
     title: "MCP/Tools",
     type: "doc",
   },
-  "docs-mcp": {
-    title: "Docs MCP",
-    type: "doc",
-  },
   tests: {
     title: "Test",
     type: "doc",
@@ -85,14 +81,14 @@ export default {
     title: "Vibe Build",
     type: "doc",
   },
+  templates: {
+    title: "Templates",
+    href: "/docs/templates",
+    newWindow: false,
+  },
 
   // interface: {
   //   title: "Interface",
-  //   type: "doc",
-  // },
-
-  // templates: {
-  //   title: "Templates",
   //   type: "doc",
   // },
 
@@ -166,7 +162,11 @@ export default {
     type: "separator",
     title: "REFERENCES",
   },
-  
+
+  "docs-mcp": {
+    title: "Docs MCP",
+    type: "doc",
+  },
   contributing: {
     title: "Contributing",
     type: "doc",

--- a/pages/docs/_meta.ts
+++ b/pages/docs/_meta.ts
@@ -163,6 +163,11 @@ export default {
     title: "Glossary",
     type: "doc",
   },
+  "nodes-ref": {
+    "title": "All Nodes (A-Z)",
+    "href": "/docs/nodes",
+    "newWindow": false
+  },
   "docs-mcp": {
     title: "Docs MCP",
     type: "doc",
@@ -170,16 +175,6 @@ export default {
   contributing: {
     title: "Contributing",
     type: "doc",
-  },
-  "nodes-ref": {
-    "title": "All Nodes (A-Z)",
-    "href": "/docs/nodes",
-    "newWindow": false
-  },
-  "integrations-ref": {
-    "title": "All Integrations (A-Z)",
-    "href": "/integrations",
-    "newWindow": false
   },
 
   // "roadmap-ref": {

--- a/pages/docs/_meta.ts
+++ b/pages/docs/_meta.ts
@@ -16,10 +16,7 @@ export default {
     type: "doc",
   },
 
-  glossary: {
-    title: "Glossary",
-    type: "doc",
-  },
+  
   concepts: {
     title: "Concepts",
     type: "doc",
@@ -158,11 +155,14 @@ export default {
     title: "Feedback API",
     type: "doc",
   },
-  "REFERENCES": {
+  "MORE": {
     type: "separator",
-    title: "REFERENCES",
+    title: "MORE",
   },
-
+  glossary: {
+    title: "Glossary",
+    type: "doc",
+  },
   "docs-mcp": {
     title: "Docs MCP",
     type: "doc",

--- a/pages/docs/docs-mcp.mdx
+++ b/pages/docs/docs-mcp.mdx
@@ -96,7 +96,7 @@ Your Question
       ↓
 MCP Client (Claude / Cursor)
       ↓
-docmcp.lamatic.ai/api/mcp/api
+docmcp.lamatic.ai/mcp/api
       ↓
 Lamatic RAG Flow
       ↓

--- a/pages/docs/docs-mcp.mdx
+++ b/pages/docs/docs-mcp.mdx
@@ -36,7 +36,7 @@ Add this to your MCP client config:
 {
   "mcpServers": {
     "lamatic-docs": {
-      "url": "https://lamatic-mcp-docs.vercel.app/api/mcp"
+      "url": "https://docmcp.lamatic.ai/api/mcp"
     }
   }
 }
@@ -51,7 +51,7 @@ Add this to your MCP client config:
 {
   "mcpServers": {
     "lamatic-docs": {
-      "url": "https://lamatic-mcp-docs.vercel.app/api/mcp"
+      "url": "https://docmcp.lamatic.ai/api/mcp"
     }
   }
 }
@@ -96,7 +96,7 @@ Your Question
       ↓
 MCP Client (Claude / Cursor)
       ↓
-lamatic-mcp-docs.vercel.app/api/mcp
+docmcp.lamatic.ai/api/mcp/api
       ↓
 Lamatic RAG Flow
       ↓

--- a/pages/docs/docs-mcp.mdx
+++ b/pages/docs/docs-mcp.mdx
@@ -1,0 +1,148 @@
+---
+title: Lamatic Docs MCP
+description: Query Lamatic.ai documentation instantly using AI — powered by RAG and Model Context Protocol.
+---
+
+import { Callout, Cards, Card } from 'nextra/components'
+
+# Lamatic Docs MCP
+
+> Query Lamatic.ai documentation instantly from any AI assistant — no searching, no tab switching, just answers.
+
+---
+
+## What is the Docs MCP?
+
+The **Lamatic Docs MCP** is a [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI assistants like Claude, Cursor, and Windsurf direct access to Lamatic.ai documentation.
+
+
+It is powered by a RAG pipeline built entirely on Lamatic:
+- **Firecrawl** scrapes the docs
+- **Chunking + Vectorize** indexes them into a VectorDB
+- **RAG Node** answers questions semantically
+- **Next.js + Vercel** exposes the MCP endpoint publicly
+
+<Callout type="info">
+  The MCP is free to use. No API key or account required.
+</Callout>
+
+---
+
+## Connect
+
+Add this to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "lamatic-docs": {
+      "url": "https://lamatic-mcp-docs.vercel.app/api/mcp"
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`  
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "lamatic-docs": {
+      "url": "https://lamatic-mcp-docs.vercel.app/api/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving. You should see a 🔌 tools icon in the chat input.
+
+### Cursor / Windsurf / Cline
+
+Add the same config to your MCP settings. Most clients support the `url` field directly for HTTP-based MCP servers.
+
+
+## Available Tools
+
+### `query_docs`
+
+Ask any question about Lamatic.ai documentation. Uses RAG to search across all indexed docs and return a precise answer with references.
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | ✅ | The question to ask |
+
+**Example:**
+
+```json
+{
+  "name": "query_docs",
+  "arguments": {
+    "text": "How do I set up a RAG node in Lamatic?"
+  }
+}
+```
+
+---
+
+## How It Works
+
+```
+Your Question
+      ↓
+MCP Client (Claude / Cursor)
+      ↓
+lamatic-mcp-docs.vercel.app/api/mcp
+      ↓
+Lamatic RAG Flow
+      ↓
+VectorDB (indexed Lamatic docs)
+      ↓
+Answer
+```
+
+The entire pipeline is built on Lamatic:
+
+1. **Indexing Flow** — scrapes `lamatic.ai/docs` using Firecrawl, chunks content, vectorizes and stores in VectorDB
+2. **Query Flow** — takes your question, runs semantic search, generates answer
+3. **MCP Server** — Next.js API route deployed on Vercel, calls the query flow via GraphQL
+
+---
+
+## Supported Clients
+
+| Client | Supported |
+|--------|-----------|
+| Claude Desktop | ✅ |
+| Cursor | ✅ |
+| Windsurf | ✅ |
+| Cline | ✅ |
+| Any HTTP MCP client | ✅ |
+
+---
+
+## Source Code
+
+The MCP is open source. You can view, fork, and contribute on GitHub:
+
+[github.com/Lamatic/Lamatic-MCP-Docs](https://github.com/Lamatic/Lamatic-MCP-Docs)
+
+{/*
+<Callout type="tip">
+  Want to build your own Docs MCP for your company? See the [Docs MCP setup guide](/docs/mcp-tools/docs-mcp) — fork the repo, connect your own Lamatic flow, and deploy to Vercel in minutes.
+</Callout>
+*/}
+
+---
+
+## Feedback
+
+Found an issue or want to suggest an improvement?
+
+- [Open an issue on GitHub](https://github.com/Lamatic/Lamatic-MCP-Docs/issues)
+- [Join Lamatic Slack](https://lamatic.ai/slack)
+- [Feature board](https://product.lamatic.ai/)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- SidebarCollapse updated: component now tracks and persists expanded sections (localStorage key "sidebar-expanded-v1") instead of collapsed state; initialization, MutationObserver, DOM-wrapping, chevrons, click handlers, and route reinit behavior preserved.
- Integrated SidebarCollapse into app layout (pages/_app.tsx) above SidebarSwitcher.
- Navigation updated (pages/docs/_meta.ts): added "Docs MCP" and "Templates", moved Glossary and Contributing under a new MORE section, removed REFERENCES separator.
- Added comprehensive MCP docs page (pages/docs/docs-mcp.mdx) containing overview, client setup/config examples (Claude Desktop, Cursor/Windsurf/Cline), query_docs tool details and examples, pipeline/diagram, supported clients, source link, and feedback guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->