### PR TITLE
Docs: Add Prompts to AI Nodes

### DIFF
--- a/pages/docs/nodes/ai/_meta.ts
+++ b/pages/docs/nodes/ai/_meta.ts
@@ -11,10 +11,6 @@ export default {
     "title": "Generate Image",
     "type": "doc"
   },
-  "multimodel-node": {
-    "title": "Multimodal",
-    "type": "doc"
-  },
   "classifier-node": {
     "title": "Classifier Node",
     "type": "doc"

--- a/pages/docs/nodes/ai/classifier-node.mdx
+++ b/pages/docs/nodes/ai/classifier-node.mdx
@@ -58,6 +58,38 @@ The Classifier Node is a powerful AI component that enables users to automatical
 
 1. Build intelligent document categorization systems for large-scale data management.
 
+## Prompt Examples
+
+### Support Ticket Router
+
+The LLM reads the input and routes the flow down the matching branch.
+
+**System Prompt**
+```
+You are a support ticket classifier. 
+Analyze the user's message and route it to the correct department.
+Use the description of each classifier to make your decision.
+Only pick one classifier. Do not explain your choice.
+```
+
+**User Prompt**
+```
+Classify this support message and route it to the right department:
+{{triggerNode_1.message}}
+```
+
+**Classifiers**
+
+| Name | Description |
+|---|---|
+| `Billing` | Payment issues, invoices, failed charges |
+| `Technical` | Bugs, errors, integration problems |
+
+Each classifier becomes a **branch in your flow** — add the next nodes
+(e.g. send to Slack, trigger an email) inside each branch.
+
+> The Description field helps the LLM decide which branch to pick on ambiguous inputs.
+
 ## Setup
 
 ### Select the Classifier Node

--- a/pages/docs/nodes/ai/doc-extractor.mdx
+++ b/pages/docs/nodes/ai/doc-extractor.mdx
@@ -53,6 +53,64 @@ The Doc Extractor node extracts content from a document URL (PDF or image), send
 3. Contract or policy document summarization workflows
 4. Document-to-JSON enrichment pipelines for databases and APIs
 
+## Prompt Examples
+
+### Invoice Data Extractor
+
+Extracts key fields from an invoice PDF.
+
+**Document URL**
+```
+{{triggerNode_1.document_url}}
+```
+
+**System Prompt**
+```
+Extract the following fields from this invoice:
+- Invoice number
+- Vendor name
+- Invoice date
+- Due date
+- Line items (description, quantity, unit price)
+- Total amount
+
+Return as JSON. Use null for any field not found in the document.
+```
+
+**Settings**
+- Output Format: `JSON`
+- Join Pages: `On`
+
+---
+
+### Resume Parser
+
+Extracts candidate details from a resume PDF.
+
+**Document URL**
+```
+{{triggerNode_1.document_url}}
+```
+
+**System Prompt**
+```
+Extract the following details from this resume:
+- Full name
+- Email address
+- Phone number
+- Current job title
+- Years of experience
+- Top 5 skills
+
+Return as JSON. Use null for any field not found.
+```
+
+**Settings**
+- Output Format: `JSON`
+- Join Pages: `On`
+
+> Use `JSON` output format when passing data to downstream nodes. Switch to `Markdown` only for human-readable reports.
+
 ## Setup
 
 ### Select the Doc Extractor Node

--- a/pages/docs/nodes/ai/generate-image-node.mdx
+++ b/pages/docs/nodes/ai/generate-image-node.mdx
@@ -49,6 +49,32 @@ The Generate Image Node is a powerful AI component that creates images from text
 1. Creation of personalized artwork or graphics for social media posts.
 1. Development of dynamic website features that adapt visuals based on user input.
 
+## Prompt Examples
+
+### Product Visual Generator
+
+Generates a product image based on a description.
+
+**User Prompt**
+```
+A high-quality product photo of {{triggerNode_1.product_name}}.
+Clean white background, studio lighting, sharp focus, photorealistic.
+```
+
+---
+
+### Social Media Banner
+
+Generates a banner image for a social media post.
+
+**User Prompt**
+```
+A modern social media banner for {{triggerNode_1.topic}}.
+Vibrant colors, bold typography, minimalist design, 16:9 ratio.
+```
+
+>  The more specific your prompt, the better the output. Always include style, lighting, background, and mood for best results.
+
 ## Setup
 
 ### Select the Image Generate Node

--- a/pages/docs/nodes/ai/generate-json-node.mdx
+++ b/pages/docs/nodes/ai/generate-json-node.mdx
@@ -61,6 +61,39 @@ The Generate JSON Node is a specialized AI component that generates structured J
 1. Build interactive tools that convert conversational inputs into structured JSON for use in various applications.
 1. Design flow for content generation that require consistency in data formatting across different platforms.
 
+## Prompt Examples
+
+### Structured Data Generator
+
+Extracts key information from a user input and returns it as structured JSON.
+
+**System Prompt**
+```
+You are a data extraction assistant.
+Read the input and return only a valid JSON object.
+Do not add any explanation or extra text outside the JSON.
+```
+
+**User Prompt**
+```
+Extract the following details from this text and return as JSON:
+{{triggerNode_1.message}}
+```
+
+**Output Schema Example**
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "email": { "type": "string" },
+    "issue": { "type": "string" }
+  }
+}
+```
+
+>  Define your schema fields clearly so the LLM knows exactly what to extract. Add more fields to the schema as needed.
+
 ## Setup
 
 ### Select the JSON Generate Node

--- a/pages/docs/nodes/ai/generate-text-node.mdx
+++ b/pages/docs/nodes/ai/generate-text-node.mdx
@@ -58,6 +58,50 @@ The Generate Text node allows users to programmatically generate text outputs by
 1. Automated report generation systems for business intelligence and data analysis.
 1. Customizable email and message drafting tools for improved communication efficiency.
 
+## Prompt Examples
+
+### Summarize
+
+Condenses a long piece of text into a short, clear summary.
+
+**System Prompt**
+```
+You are a summarization assistant.
+Summarize the given text in 3-5 sentences.
+Be concise and keep only the most important points.
+Do not add any information that is not in the original text.
+```
+
+**User Prompt**
+```
+Summarize the following text:
+{{triggerNode_1.content}}
+```
+
+> Note: To make the summary shorter or longer, update the sentence count in the System Prompt.
+
+---
+
+### Score Generator
+
+Evaluates an input and returns a score with a short reason.
+
+**System Prompt**
+```
+You are a scoring assistant.
+Read the input and give it a score from 1 to 10 based on quality and relevance.
+Return the score followed by a one-line reason.
+Format: Score: X/10 — Reason: <your reason>
+```
+
+**User Prompt**
+```
+Score the following response:
+{{triggerNode_1.response}}
+```
+
+> Update the scoring criteria in the System Prompt to match your use case (e.g. clarity, tone, accuracy).
+
 ## Setup
 
 ### Select the Text LLM Node

--- a/pages/docs/nodes/ai/mcp-node.mdx
+++ b/pages/docs/nodes/ai/mcp-node.mdx
@@ -67,6 +67,51 @@ The MCP Node enables seamless integration with external data sources, APIs, and 
 5. **Real-time Monitoring Systems** - Access live data feeds for monitoring and alerts
 6. **Custom Tool Integration** - Use specialized tools and functions provided by MCP servers
 
+## Prompt Examples
+
+### GitHub User Lookup
+
+Fetches GitHub user details using the GitHub MCP server.
+
+**Query**
+```
+{{triggerNode_1.user_query}}
+```
+
+**Prompt (optional)**
+```
+You are a GitHub assistant. Use the available tools to fetch the
+requested information and return a clear, concise summary.
+Only use information returned by the tools. Do not make up details.
+```
+
+**Selected Tools**
+- Select credentials first to load available tools, then enable the tools relevant to your use case (e.g. `get_user`, `list_issues`)
+
+---
+
+### Slack Notification Sender
+
+Sends a message to a Slack channel based on flow output.
+
+**Query**
+```
+Send a message to the #{{triggerNode_1.channel}} channel:
+{{triggerNode_1.message}}
+```
+
+**Prompt (optional)**
+```
+You are a Slack assistant.
+Use the available tools to send the message to the correct channel.
+Confirm once the message has been sent successfully.
+```
+
+**Selected Tools**
+- Select credentials first, then enable the `send_message` tool
+
+> Selected Tools only appear after you select your MCP Server credentials. Connect your MCP Server first before configuring this node.
+
 ## Setup
 
 ### Configure MCP Server

--- a/pages/docs/nodes/ai/multimodal-node.mdx
+++ b/pages/docs/nodes/ai/multimodal-node.mdx
@@ -59,6 +59,57 @@ The Multimodal Node is an advanced AI component that can process and analyze mul
 1. Build interactive applications where user actions on images are analyzed to generate contextual feedback.
 1. Design systems that maintain consistent tone and style across generated content based on previous interactions.
 
+## Prompt Examples
+
+### Image Analyser
+
+Analyses an uploaded image and returns a detailed description.
+
+**System Prompt**
+```
+You are an image analysis assistant.
+Describe the content of the image in detail.
+Include objects, colors, layout, and any visible text.
+```
+
+**User Prompt**
+```
+Analyse this image and describe what you see:
+{{triggerNode_1.image_url}}
+```
+
+**Attachments**
+```
+{{triggerNode_1.image_url}}
+```
+
+---
+
+### Product Image Reviewer
+
+Reviews a product image and returns quality feedback.
+
+**System Prompt**
+```
+You are a product image quality reviewer.
+Look at the image and evaluate it on: background clarity,
+lighting, product visibility, and overall quality.
+Return a short assessment with improvement suggestions if needed.
+```
+
+**User Prompt**
+```
+Review this product image:
+{{triggerNode_1.image_url}}
+```
+
+**Attachments**
+```
+{{triggerNode_1.image_url}}
+```
+
+> Always pass the image URL in both the Attachments field and the User Prompt so the model has full context.
+
 ## Setup
 
 ### Select the Multimodal Text Node

--- a/pages/docs/nodes/ai/rag-node.mdx
+++ b/pages/docs/nodes/ai/rag-node.mdx
@@ -62,6 +62,53 @@ The node allows users to configure parameters such as the embedding model, gener
 1. Build educational tools that generate tailored learning content and explanations by leveraging context from a vector database.
 1. Design content creation platforms that use RAG to produce more relevant and concise articles or reports based on user input.
 
+## Prompt Examples
+
+### Knowledge Base Q&A
+
+Answers user questions using content from your vector database.
+
+**System Prompt**
+```
+You are a helpful assistant. Answer the user's question using only
+the context retrieved from the knowledge base.
+If the answer is not in the context, say "I don't have that information."
+Do not make up answers.
+```
+
+**Search Query**
+```
+{{triggerNode_1.question}}
+```
+
+**Settings**
+- No. of References: `5`
+- Certainty: `0.7`
+
+---
+
+### Product Documentation Assistant
+
+Helps users find answers from your product docs.
+
+**System Prompt**
+```
+You are a product support assistant. Use the retrieved documentation
+to answer the user's question clearly and concisely.
+Always reference the relevant section when possible.
+```
+
+**Search Query**
+```
+{{triggerNode_1.user_query}}
+```
+
+**Settings**
+- No. of References: `3`
+- Certainty: `0.75`
+
+> Increase Certainty closer to 1.0 for more precise matches. Lower it (e.g. 0.5) to return broader results when your knowledge base is small.
+
 ## Setup
 
 ### Select the RAG Node

--- a/pages/docs/nodes/ai/supervisor-node.mdx
+++ b/pages/docs/nodes/ai/supervisor-node.mdx
@@ -52,6 +52,58 @@ The **Supervisor Node** is an advanced AI component that provides oversight and 
 - Automated AI systems that require iterative questioning to refine responses.
 - Intelligent customer support agents that engage in structured dialogues.
 
+## Prompt Examples
+
+### Research + Writer Agent
+
+Coordinates a Research agent and a Writer agent to produce final content.
+Each agent becomes a branch in your flow, add the relevant nodes inside each.
+
+**System Prompt**
+```
+You are a supervisor coordinating two agents: Research and Writer.
+First, send the task to the Research agent to gather information on the topic.
+Then pass that research to the Writer agent to produce a clear, structured response.
+Stop once the Writer has completed the response.
+```
+
+**Agent Paths**
+
+| Name | Description |
+|---|---|
+| `Research` | Searches and retrieves relevant information on the given topic |
+| `Writer` | Takes the research and writes a clear, structured response |
+
+**Settings**
+- Max Iterations: `5`
+- Stop Word: `DONE`
+
+---
+
+### Customer Support Triage
+
+Collects the user's issue and routes to the right agent.
+
+**System Prompt**
+```
+You are a customer support supervisor.
+Ask the user to describe their issue, then route to the correct agent:
+Billing for payment issues, Technical for product problems.
+Stop once the issue is resolved.
+```
+
+**Agent Paths**
+
+| Name | Description |
+|---|---|
+| `Billing` | Handles payment, invoice, and subscription issues |
+| `Technical` | Handles bugs, errors, and product problems |
+
+**Settings**
+- Max Iterations: `5`
+- Stop Word: `RESOLVED`
+
+> The Supervisor loops through agents until the Stop Word appears in the response or Max Iterations is reached. Always set both to avoid infinite loops.
 
 ## Setup
 


### PR DESCRIPTION
Added examples for the AI nodes.
Removed "Multimodal" page that was redirecting to "Classifier" Node. Multimodal already exists and it is called "Multimodal Node" 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Removed** `multimodal-node` redirect entry from AI node docs metadata (`_meta.ts`)
- **Added "Prompt Examples" sections** to 8 AI node documentation pages with concrete, copyable templates:
  - Classifier Node - Support Ticket Router example
  - Doc Extractor Node - Invoice & resume parsing templates
  - Generate Image Node - Product Visual & Social Media Banner examples
  - Generate JSON Node - Structured Data Generator example
  - Generate Text Node - Summarize & Score Generator examples
  - MCP Node - GitHub lookup & Slack notification examples
  - Multimodal Node - Image Analyzer & Product Review examples
  - RAG Node - Knowledge Base Q&A & Documentation Assistant examples
  - Supervisor Node - Research+Writer & Customer Support Triage examples

All examples include system prompts, user prompts, and relevant configuration settings for practical reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lamatic/Lamatic-Docs/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->