### PR TITLE
MCP: Add Dev and Graph MCP Doc pages

### DIFF
--- a/pages/docs/_meta.ts
+++ b/pages/docs/_meta.ts
@@ -172,6 +172,14 @@ export default {
     title: "Docs MCP",
     type: "doc",
   },
+  "graph-mcp": {
+    title: "Graph MCP",
+    type: "doc",
+  },
+  "dev-mcp": {
+    title: "Dev MCP",
+    type: "doc",
+  },
   contributing: {
     title: "Contributing",
     type: "doc",

--- a/pages/docs/dev-mcp.mdx
+++ b/pages/docs/dev-mcp.mdx
@@ -1,0 +1,187 @@
+---
+title: Dev MCP
+description: Manage your Lamatic projects, flows, credentials, and more via AI agents.
+---
+
+import { Callout } from 'nextra/components'
+
+# Dev MCP
+
+> Manage your Lamatic projects, flows, credentials, and more via AI agents.
+
+---
+
+## What is it?
+
+**Lamatic Dev MCP** is an [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI agents like Claude, GitHub Copilot, and Cursor full control over your Lamatic organization — create projects, manage flows, handle credentials, deployments, integrations, and more.
+
+---
+
+## Installation
+
+```bash
+# Run directly via npx (recommended)
+npx @lamatic/dev-mcp
+
+# Or install globally
+npm install -g @lamatic/dev-mcp
+
+# Or install as a dependency
+npm install @lamatic/dev-mcp
+```
+
+---
+
+## Setup
+
+### Claude Code
+
+```bash
+claude mcp add lamatic-dev -- npx -y @lamatic/dev-mcp
+```
+
+### VS Code
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "lamatic-dev": {
+      "command": "npx",
+      "args": ["-y", "@lamatic/dev-mcp"],
+      "type": "stdio"
+    }
+  }
+}
+```
+
+### Claude Desktop / Cursor
+
+Add to your MCP config file:
+
+```json
+{
+  "mcpServers": {
+    "lamatic-dev": {
+      "command": "npx",
+      "args": ["-y", "@lamatic/dev-mcp"]
+    }
+  }
+}
+```
+
+---
+
+## Authentication
+
+Once connected, run the `dev_auth_login` tool:
+
+```
+authenticate with apiKey lt-org-xxx and orgId your-org-id
+```
+
+<Callout type="info">
+  Your credentials are stored locally at `~/.lamatic/config.json`.
+</Callout>
+
+---
+
+## Tools
+
+### Projects
+
+| Tool | Description |
+|------|-------------|
+| `dev_list_projects` | List all projects in your org |
+| `dev_create_project` | Create a new project |
+| `dev_get_project` | Get project details |
+| `dev_update_project` | Rename a project |
+| `dev_delete_project` | Delete a project |
+| `dev_deploy_project` | Deploy a project |
+
+### Flows
+
+| Tool | Description |
+|------|-------------|
+| `dev_list_all_flows` | List all flows in a project |
+| `dev_create_flow` | Create a new flow |
+| `dev_get_flows` | Get flows list |
+| `dev_update_flow` | Update flow nodes and edges |
+| `dev_rename_flow` | Rename a flow |
+| `dev_delete_flow` | Delete a flow |
+| `dev_update_flow_status` | Activate or deactivate a flow |
+
+### Deployments
+
+| Tool | Description |
+|------|-------------|
+| `dev_list_all_deployments` | List all deployments |
+| `dev_get_deployment` | Get deployment details |
+
+### Contexts
+
+| Tool | Description |
+|------|-------------|
+| `dev_get_all_contexts` | List all contexts |
+| `dev_create_context` | Create a vector or memory context |
+| `dev_get_context` | Get context details |
+| `dev_delete_context` | Delete a context |
+
+### Models
+
+| Tool | Description |
+|------|-------------|
+| `dev_list_model_creds` | List model credentials |
+| `dev_list_model_providers` | List available providers |
+| `dev_check_model_status` | Check model availability |
+| `dev_create_model_creds` | Add model credentials |
+
+### Integrations
+
+| Tool | Description |
+|------|-------------|
+| `dev_list_supported_integrations` | List supported integrations |
+| `dev_list_integration_creds` | List integration credentials |
+| `dev_create_integration_creds` | Add integration credentials |
+
+### Credentials
+
+| Tool | Description |
+|------|-------------|
+| `dev_get_cred_info` | Get credential details |
+| `dev_get_oauth_url` | Get OAuth URL for an integration |
+| `dev_update_credential` | Update a credential |
+| `dev_delete_credential` | Delete a credential |
+
+---
+
+## Example Usage
+
+```
+list all my Lamatic projects
+```
+
+```
+create a new project called "my-ai-app" in us-east-1
+```
+
+```
+list all flows in project fcd1aa1d-...
+```
+
+```
+rename flow abc123 to "New Flow Name"
+```
+
+```
+deploy project fcd1aa1d-...
+```
+
+---
+
+## Links
+
+- [GitHub repository](https://github.com/Lamatic/Dev-MCP-Lamatic)
+- [npm package](https://www.npmjs.com/package/@lamatic/dev-mcp)
+- [Graph MCP](/docs/graph-mcp) — Execute Lamatic flows via AI

--- a/pages/docs/graph-mcp.mdx
+++ b/pages/docs/graph-mcp.mdx
@@ -1,0 +1,149 @@
+---
+title: Graph MCP
+description: Execute your deployed Lamatic flows via AI agents using natural language.
+---
+
+import { Callout, Tabs } from 'nextra/components'
+
+# Graph MCP
+
+> Execute your deployed Lamatic flows via AI agents using natural language.
+
+---
+
+## What is it?
+
+**Lamatic Graph MCP** is an [Model Context Protocol](https://modelcontextprotocol.io) server that turns your deployed Lamatic flows into AI-callable tools. Connect Claude, GitHub Copilot, or Cursor — your flows become tools your AI can call directly using natural language.
+
+---
+
+## Installation
+
+```bash
+# Run directly via npx (recommended)
+npx @lamatic/graph-mcp
+
+# Or install globally
+npm install -g @lamatic/graph-mcp
+
+# Or install as a dependency
+npm install @lamatic/graph-mcp
+```
+
+---
+
+## Setup
+
+### Claude Code
+
+```bash
+claude mcp add lamatic-graph -- npx -y @lamatic/graph-mcp
+```
+
+### VS Code
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "lamatic-graph": {
+      "command": "npx",
+      "args": ["-y", "@lamatic/graph-mcp"],
+      "type": "stdio"
+    }
+  }
+}
+```
+
+### Claude Desktop / Cursor
+
+Add to your MCP config file:
+
+```json
+{
+  "mcpServers": {
+    "lamatic-graph": {
+      "command": "npx",
+      "args": ["-y", "@lamatic/graph-mcp"]
+    }
+  }
+}
+```
+
+---
+
+## Authentication
+
+Graph MCP requires two API keys: an **org-level key** and a **project-level key**.
+
+Run the `graph_auth_login` tool:
+
+```
+authenticate with orgApiKey lt-org-xxx, projectApiKey lt-mmup-xxx and orgId your-org-id
+```
+
+<Callout type="info">
+  Your credentials are stored locally at `~/.lamatic/config.json`.
+</Callout>
+
+---
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `graph_auth_login` | Authenticate with Lamatic |
+| `graph_load_project_flows` | Load all active flows with input schemas |
+| `graph_execute_flow` | Execute a deployed flow with a payload |
+| `graph_refresh_flows` | Refresh the list of active flows |
+
+---
+
+## Supported Flow Triggers
+
+Graph MCP can execute flows with the following trigger types:
+
+| Trigger | Supported |
+|---------|-----------|
+| API Request | ✅ |
+| Chat Widget | ✅ |
+| Search Widget | ✅ |
+| Webhook | ✅ |
+
+---
+
+## How It Works
+
+1. Connect your MCP client with **org API key + project API key + org ID**
+2. Run `graph_load_project_flows` to see all active flows and their input fields
+3. Run `graph_execute_flow` with the flow ID and matching payload
+4. The AI maps your natural language to the right flow and payload automatically
+
+---
+
+## Example Usage
+
+```
+show me all flows for project fcd1aa1d-...
+```
+
+```
+run the Changelog flow with sampleInput "hello world"
+```
+
+```
+execute the RAG flow and ask it "what is Lamatic?"
+```
+
+```
+refresh my flows
+```
+
+---
+
+## Links
+
+- [GitHub repository](https://github.com/Lamatic/GraphMCP-Lamatic)
+- [npm package](https://www.npmjs.com/package/@lamatic/graph-mcp)
+- [Dev MCP](/docs/dev-mcp) — Manage Lamatic projects via AI


### PR DESCRIPTION
Added Dev MCP and Graph MCP to the Lamatic Docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- Updated documentation navigation in `pages/docs/_meta.ts` to include two new MCP documentation entries: `graph-mcp` and `dev-mcp`

- Added `pages/docs/dev-mcp.mdx` with documentation for Lamatic Dev MCP server, including:
  - Installation and setup instructions for Claude Code, VS Code, Claude Desktop/Cursor
  - Authentication workflow with local credential storage
  - MCP tools catalog organized by domain (Projects, Flows, Deployments, Contexts, Models, Integrations, Credentials)
  - Example usage commands and links to GitHub repository and npm package

- Added `pages/docs/graph-mcp.mdx` with documentation for Graph MCP server, including:
  - Installation and client configuration examples
  - Authentication using `graph_auth_login` with org and project API keys
  - Available tools: `graph_auth_login`, `graph_load_project_flows`, `graph_execute_flow`, `graph_refresh_flows`
  - Supported trigger types and "How It Works" section
  - Example user prompts and links to GitHub repository and npm package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->