### PR TITLE
CLI: Add Lamatic CLI

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -681,7 +681,8 @@ const permanentRedirects = [
 ["/docs/api-integration/sdk/go","/docs/sdk/go"],
 ["/docs/api-integration/sdk/next","/docs/sdk/next"],
 ["/docs/api-integration/sdk/react","/docs/sdk/react"],
-["/docs/api-integration/integration-guide","/docs/sdk/integration-guide"]
+["/docs/api-integration/integration-guide","/docs/sdk/integration-guide"],
+["/docs/docs-mcp","/docs/mcp/docs-mcp"]
 
 
 ];

--- a/pages/docs/_meta.ts
+++ b/pages/docs/_meta.ts
@@ -133,6 +133,10 @@ export default {
     title: "SDK",
     type: "doc",
   },
+  cli: {
+    title: "CLI",
+    type: "doc",
+  },
   mcp: {
     title: "MCP",
     type: "doc",
@@ -171,10 +175,6 @@ export default {
     "title": "All Nodes (A-Z)",
     "href": "/docs/nodes",
     "newWindow": false
-  },
-  "docs-mcp": {
-    title: "Docs MCP",
-    type: "doc",
   },
   "dev-mcp": {
     title: "Dev MCP",

--- a/pages/docs/api-integration/api-key.mdx
+++ b/pages/docs/api-integration/api-key.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Keys
-description: Lamatic.ai uses API keys to authenticate access. There are two types — Project API Keys for triggering deployed flows, and Enterprise API Keys for managing your organization.
+description: Lamatic.ai uses API keys to authenticate access. There are two types - Project API Keys for triggering deployed flows, and Enterprise API Keys for managing your organization.
 ---
 # API Keys
 
@@ -48,7 +48,7 @@ The Enterprise (org-level) API key (`lt-org-...`) is used for managing your Lama
 - Managing flows (create, update, delete)
 - Managing credentials (model keys, integrations)
 - Managing contexts and deployments
-- Listing resources across your org — and much more
+- Listing resources across your org, and much more
 
 ## When to use which
 

--- a/pages/docs/api-integration/index.mdx
+++ b/pages/docs/api-integration/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Overview
-description: How to integrate with Lamatic programmatically — GraphQL, REST-style usage, and when to use the SDK.
+description: How to integrate with Lamatic programmatically. GraphQL, REST-style usage, and when to use the SDK.
 ---
 
 # API Overview
@@ -11,9 +11,9 @@ Lamatic exposes a **GraphQL API** as the primary way to run Flows from your app,
 
 Most developer tools use REST (`POST /api/v1/flows/{id}/execute`). Lamatic uses **GraphQL** because:
 
-- **Dynamic schemas** — The shape of inputs and outputs depends on how your Flow is configured. GraphQL lets you request exactly the fields you need and matches the response to your Flow's schema.
-- **Single endpoint** — One URL per project; the operation and variables are in the request body.
-- **Strong typing** — Queries and responses align with your Flow's input/output definitions.
+- **Dynamic schemas**: The shape of inputs and outputs depends on how your Flow is configured. GraphQL lets you request exactly the fields you need and matches the response to your Flow's schema.
+- **Single endpoint**: One URL per project; the operation and variables are in the request body.
+- **Strong typing**: Queries and responses align with your Flow's input/output definitions.
 
 If you're used to REST, you can think of "execute a Flow" as a single mutation: `executeWorkflow(workflowId, payload)`.
 
@@ -58,7 +58,7 @@ The response includes `status` (e.g. `success`) and `result` (your Flow's output
 
 ## Next steps
 
-- [Integration Guide](/docs/sdk/integration-guide) — Step-by-step setup and examples in JavaScript, Python, and cURL.
-- [GraphQL](/docs/interface/graphql) — Full request/response shapes, async flows, and schema.
-- [Error Codes](/docs/error-reference) — Diagnose failed requests.
-- [Limits & Quotas](/docs/limits) — Rate limits and payload size.
+- [Integration Guide](/docs/sdk/integration-guide): Step-by-step setup and examples in JavaScript, Python, and cURL.
+- [GraphQL](/docs/interface/graphql): Full request/response shapes, async flows, and schema.
+- [Error Codes](/docs/error-reference): Diagnose failed requests.
+- [Limits & Quotas](/docs/limits): Rate limits and payload size.

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -1,0 +1,214 @@
+---
+title: Lamatic CLI (Beta)
+description: The official Lamatic CLI for managing projects, flows, deployments, contexts, models, and integrations from the terminal.
+---
+
+import { Callout } from "nextra/components";
+
+# CLI
+
+`@lamatic/cli` is the official command-line interface for managing your Lamatic organization. Create projects, manage flows, trigger deployments, and configure contexts and integrations, all from the terminal.
+
+---
+
+## Installation
+
+Install globally to use the `lamatic` command anywhere:
+
+```bash
+npm install -g @lamatic/cli
+```
+
+Or run on demand without installing:
+
+```bash
+npx @lamatic/cli <command>
+```
+
+---
+
+## Authentication
+
+Authenticate once with your API key, organization ID, and user ID. Credentials are cached locally so subsequent commands don't require re-entering them.
+
+```bash
+lamatic auth login \
+  --api-key <YOUR_API_KEY> \
+  --org-id <YOUR_ORG_ID> \
+  --user-id <YOUR_USER_ID>
+```
+
+| Command | Description |
+|---|---|
+| `lamatic auth login` | Authenticate with your API key |
+| `lamatic auth status` | Check current auth status |
+| `lamatic auth logout` | Logout and clear credentials |
+
+---
+
+## Help
+
+```bash
+lamatic --help
+lamatic <command> --help
+```
+
+---
+
+## Commands
+
+### Projects
+
+| Command | Description |
+|---|---|
+| `lamatic init <name>` | Create a new Lamatic project |
+| `lamatic project list` | List all projects in your org |
+| `lamatic project get` | Fetch and download a project locally |
+| `lamatic project delete` | Delete a project |
+
+```bash
+# Create a new project
+lamatic init my-project --scratch
+
+# List all projects
+lamatic project list
+
+# Download an existing project locally
+lamatic project get --project-id <PROJECT_ID>
+
+# Delete a project
+lamatic project delete --project-id <PROJECT_ID>
+```
+
+### Flows
+
+| Command | Description |
+|---|---|
+| `lamatic flows create` | Create a new flow in a project |
+| `lamatic flows list` | List all flows in a project |
+| `lamatic flows rename` | Rename a flow |
+| `lamatic flows delete` | Delete a flow |
+| `lamatic flows status` | Update flow status (active/inactive) |
+
+```bash
+# Create a flow
+lamatic flows create --project-id <PROJECT_ID> --name "My Flow"
+
+# List all flows
+lamatic flows list --project-id <PROJECT_ID>
+
+# Rename a flow
+lamatic flows rename --project-id <PROJECT_ID> --flow-id <FLOW_ID> --name "New Name"
+
+# Delete a flow
+lamatic flows delete --project-id <PROJECT_ID> --flow-id <FLOW_ID>
+
+# Update flow status
+lamatic flows status --project-id <PROJECT_ID> --flow-id <FLOW_ID> --status active
+```
+
+### Deployments
+
+| Command | Description |
+|---|---|
+| `lamatic deploy` | Trigger a deployment for a project |
+| `lamatic deployments list` | List all deployments |
+| `lamatic deployments get` | Get details of a specific deployment |
+
+```bash
+# Trigger a deployment
+lamatic deploy --project-id <PROJECT_ID>
+
+# List all deployments
+lamatic deployments list --project-id <PROJECT_ID>
+
+# Get deployment details
+lamatic deployments get --project-id <PROJECT_ID> --deployment-id <DEPLOYMENT_ID>
+```
+
+### Contexts
+
+| Command | Description |
+|---|---|
+| `lamatic contexts list` | List all contexts in a project |
+| `lamatic contexts create` | Create a new context (vector or memory) |
+| `lamatic contexts delete` | Delete a context |
+
+```bash
+# List contexts
+lamatic contexts list --project-id <PROJECT_ID>
+
+# Create a context
+lamatic contexts create --project-id <PROJECT_ID> --name "my-context" --type vector
+
+# Delete a context
+lamatic contexts delete --project-id <PROJECT_ID> --context-id <CONTEXT_ID>
+```
+
+### Models
+
+| Command | Description |
+|---|---|
+| `lamatic models list` | List all model credentials |
+| `lamatic models add` | Add a new model credential |
+
+```bash
+# List model credentials
+lamatic models list --project-id <PROJECT_ID>
+
+# Add a model credential
+lamatic models add --project-id <PROJECT_ID>
+```
+
+### Integrations
+
+| Command | Description |
+|---|---|
+| `lamatic integrations list` | List all integration credentials |
+| `lamatic integrations add` | Add a new integration |
+
+```bash
+# List integrations
+lamatic integrations list --project-id <PROJECT_ID>
+
+# Add an integration
+lamatic integrations add --project-id <PROJECT_ID>
+```
+
+---
+
+## Example Workflow
+
+A typical end-to-end flow: log in, create a project, add a flow, deploy, and verify.
+
+```bash
+# 1. Login
+lamatic auth login --api-key <key> --org-id <org_id> --user-id <user_id>
+
+# 2. Create a new project
+lamatic init my-project --scratch
+
+# 3. List your projects to grab the project ID
+lamatic project list
+
+# 4. Create a flow inside the project
+lamatic flows create --project-id <PROJECT_ID> --name "My Flow"
+
+# 5. Deploy the project
+lamatic deploy --project-id <PROJECT_ID>
+
+# 6. Check deployment status
+lamatic deployments list --project-id <PROJECT_ID>
+
+# 7. Download an existing project locally
+lamatic project get --project-id <PROJECT_ID>
+```
+
+---
+
+## Links
+
+- [npm package](https://www.npmjs.com/package/@lamatic/cli)
+- [API Keys](/docs/api-integration/api-key): where to find the credentials this CLI uses
+- [SDK](/docs/sdk): programmatic access from your application code
+- [Graph MCP](/docs/mcp/graph-mcp): execute deployed flows from any AI assistant

--- a/pages/docs/context.mdx
+++ b/pages/docs/context.mdx
@@ -70,7 +70,7 @@ Lamatic integrates **Weaviate**, a powerful vector database, to provide efficien
 
 ---
 
-### Memories (Beta)
+### Memories
 Memory systems offer another approach to providing context, particularly useful for maintaining continuity in conversations and personalizing interactions over time.
 
 #### When to Use Memories
@@ -79,7 +79,7 @@ Memories are particularly valuable in scenarios requiring long-term context rete
 > 🔄 **Pro Tip**: Use memories for long-term user preferences and ongoing conversations.
 
 
-#### Lamatic's Built-in Memories Powered by mem0 ( Beta )
+#### Lamatic's Built-in Memories Powered by mem0
 Lamatic incorporates **mem0**, a cutting-edge memory system, to enhance its context-awareness capabilities. This feature allows the platform to remember and utilize important information across multiple interactions, leading to more personalized and contextually relevant outputs.
 
 > 💡 **Tip**: Leverage mem0 for enhanced personalization and context awareness over time.

--- a/pages/docs/dev-mcp.mdx
+++ b/pages/docs/dev-mcp.mdx
@@ -13,7 +13,7 @@ import { Callout } from 'nextra/components'
 
 ## What is it?
 
-**Lamatic Dev MCP** is an [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI agents like Claude, GitHub Copilot, and Cursor full control over your Lamatic organization — create projects, manage flows, handle credentials, deployments, integrations, and more.
+**Lamatic Dev MCP** is an [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI agents like Claude, GitHub Copilot, and Cursor full control over your Lamatic organization. Create projects, manage flows, handle credentials, deployments, integrations, and more.
 
 ---
 
@@ -184,4 +184,4 @@ deploy project fcd1aa1d-...
 
 - [GitHub repository](https://github.com/Lamatic/Dev-MCP-Lamatic)
 - [npm package](https://www.npmjs.com/package/@lamatic/dev-mcp)
-- [Graph MCP](/docs/mcp/graph-mcp) — Execute Lamatic flows via AI
+- [Graph MCP](/docs/mcp/graph-mcp): Execute Lamatic flows via AI

--- a/pages/docs/mcp/_meta.ts
+++ b/pages/docs/mcp/_meta.ts
@@ -11,4 +11,8 @@ export default {
     title: "Graph MCP",
     type: "doc",
   },
+  "docs-mcp": {
+    title: "Docs MCP",
+    type: "doc",
+  },
 };

--- a/pages/docs/mcp/docs-mcp.mdx
+++ b/pages/docs/mcp/docs-mcp.mdx
@@ -1,13 +1,13 @@
 ---
 title: Lamatic Docs MCP
-description: Query Lamatic.ai documentation instantly using AI — powered by RAG and Model Context Protocol.
+description: Query Lamatic.ai documentation instantly using AI, powered by RAG and Model Context Protocol.
 ---
 
 import { Callout, Cards, Card } from 'nextra/components'
 
 # Lamatic Docs MCP
 
-> Query Lamatic.ai documentation instantly from any AI assistant — no searching, no tab switching, just answers.
+> Query Lamatic.ai documentation instantly from any AI assistant. No searching, no tab switching, just answers.
 
 ---
 
@@ -107,9 +107,9 @@ Answer
 
 The entire pipeline is built on Lamatic:
 
-1. **Indexing Flow** — scrapes `lamatic.ai/docs` using Firecrawl, chunks content, vectorizes and stores in VectorDB
-2. **Query Flow** — takes your question, runs semantic search, generates answer
-3. **MCP Server** — Next.js API route deployed on Vercel, calls the query flow via GraphQL
+1. **Indexing Flow**: scrapes `lamatic.ai/docs` using Firecrawl, chunks content, vectorizes and stores in VectorDB
+2. **Query Flow**: takes your question, runs semantic search, generates answer
+3. **MCP Server**: Next.js API route deployed on Vercel, calls the query flow via GraphQL
 
 ---
 
@@ -133,7 +133,7 @@ The MCP is open source. You can view, fork, and contribute on GitHub:
 
 {/*
 <Callout type="tip">
-  Want to build your own Docs MCP for your company? See the [Docs MCP setup guide](/docs/mcp-tools/docs-mcp) — fork the repo, connect your own Lamatic flow, and deploy to Vercel in minutes.
+  Want to build your own Docs MCP for your company? See the [Docs MCP setup guide](/docs/mcp-tools/docs-mcp). Fork the repo, connect your own Lamatic flow, and deploy to Vercel in minutes.
 </Callout>
 */}
 

--- a/pages/docs/mcp/graph-mcp.mdx
+++ b/pages/docs/mcp/graph-mcp.mdx
@@ -13,7 +13,7 @@ import { Callout, Tabs } from 'nextra/components'
 
 ## What is it?
 
-**Lamatic Graph MCP** is an [Model Context Protocol](https://modelcontextprotocol.io) server that turns your deployed Lamatic flows into AI-callable tools. Connect Claude, GitHub Copilot, or Cursor — your flows become tools your AI can call directly using natural language.
+**Lamatic Graph MCP** is an [Model Context Protocol](https://modelcontextprotocol.io) server that turns your deployed Lamatic flows into AI-callable tools. Connect Claude, GitHub Copilot, or Cursor, and your flows become tools your AI can call directly using natural language.
 
 ---
 
@@ -146,4 +146,4 @@ refresh my flows
 
 - [GitHub repository](https://github.com/Lamatic/GraphMCP-Lamatic)
 - [npm package](https://www.npmjs.com/package/@lamatic/graph-mcp)
-- [Dev MCP](/docs/dev-mcp) — Manage Lamatic projects via AI
+- [Dev MCP](/docs/dev-mcp): Manage Lamatic projects via AI

--- a/pages/docs/mcp/index.mdx
+++ b/pages/docs/mcp/index.mdx
@@ -1,43 +1,49 @@
 ---
 title: MCP Overview
-description: Overview of Lamatic's Model Context Protocol (MCP) offerings — MCP Node for consuming external MCP servers, and Graph MCP for exposing your flows as tools.
+description: Overview of Lamatic's Model Context Protocol (MCP) offerings. MCP Node consumes external servers, Graph MCP exposes your flows, and Docs MCP lets you query Lamatic documentation from any AI assistant.
 ---
 
 # MCP in Lamatic
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard for connecting AI assistants to external systems — data sources, APIs, tools, and services — through a single uniform interface.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard for connecting AI assistants to external systems (data sources, APIs, tools, services) through a single uniform interface.
 
-Lamatic supports MCP in **two directions**, depending on whether your flow needs to *consume* an MCP server or *act as* one.
+Lamatic ships **three MCP-related products**, each solving a different direction of the protocol.
 
 ---
 
-## The two MCPs
+## The three MCPs
 
-### MCP Node — consume external MCP servers
+### MCP Node: consume external MCP servers
 
 The [MCP Node](/docs/mcp/mcp-node) lets a Lamatic flow connect to an existing MCP server and use its tools and data from inside your flow. You configure the server URL, headers, and protocol once; the node makes those tools available to any AI node downstream.
 
 **Use it when:** you want your flow to talk to a third-party MCP server (e.g. a weather API, a database, an internal tool catalog) and have the AI nodes inside the flow call those tools.
 
-### Graph MCP — expose your flows as MCP tools
+### Graph MCP: expose your flows as MCP tools
 
 [Graph MCP](/docs/mcp/graph-mcp) is the inverse. It turns your deployed Lamatic flows into MCP-callable tools so any MCP client (Claude Desktop, Cursor, VS Code, etc.) can invoke them with natural language.
 
-**Use it when:** you want an external AI assistant to drive your Lamatic flows — for example, a developer using Cursor to trigger a flow that generates a report.
+**Use it when:** you want an external AI assistant to drive your Lamatic flows. For example, a developer using Cursor to trigger a flow that generates a report.
+
+### Docs MCP: query Lamatic docs from any AI assistant
+
+[Docs MCP](/docs/mcp/docs-mcp) is a hosted MCP server maintained by Lamatic. It indexes [lamatic.ai/docs](https://lamatic.ai/docs) into a RAG pipeline and exposes a `query_docs` tool so any MCP client can ask natural-language questions about Lamatic and get answers with references. No setup, no API key.
+
+**Use it when:** you want your AI assistant to answer questions about Lamatic itself (its nodes, agents, integrations, error messages) instead of searching the docs manually.
 
 ---
 
 ## When to use which
 
-| | MCP Node | Graph MCP |
-|---|---|---|
-| **Direction** | Lamatic flow → external MCP server | External MCP client → Lamatic flow |
-| **Role** | Client / consumer | Server / provider |
-| **What you provide** | The URL of an external MCP server | A deployed flow with an API trigger |
-| **What you get** | External tools available inside the flow | Your flow callable from any MCP client |
-| **Typical caller** | AI nodes in your flow | Claude Desktop, Cursor, VS Code, custom agents |
-| **Auth model** | Headers / API keys you configure on the node | Org API key + Project API key |
-| **Setup location** | Studio → MCP/Tools → MCP | `npx @lamatic/graph-mcp` in the client's config |
+|                      | MCP Node                                       | Graph MCP                                      | Docs MCP                                                     |
+| -------------------- | ---------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
+| **Direction**        | Lamatic flow → external MCP server             | External MCP client → Lamatic flow             | External MCP client → Lamatic's hosted docs server           |
+| **Role**             | Client / consumer                              | Server / provider                              | Server / provider (hosted by Lamatic)                        |
+| **What you provide** | The URL of an external MCP server              | A deployed flow with an API trigger            | Nothing (it's hosted)                                        |
+| **What you get**     | External tools available inside the flow       | Your flow callable from any MCP client         | A `query_docs` tool that answers questions about Lamatic     |
+| **Typical caller**   | AI nodes in your flow                          | Claude Desktop, Cursor, VS Code, custom agents | Claude Desktop, Cursor, anyone reading the docs              |
+| **Auth model**       | Headers / API keys you configure on the node   | Org API key + Project API key                  | None (free to use)                                           |
+| **Setup location**   | Studio → MCP/Tools → MCP                       | `npx @lamatic/graph-mcp` in the client's config | Add `https://docmcp.lamatic.ai/api/mcp` to your client config |
 
 ---
 
@@ -45,11 +51,11 @@ The [MCP Node](/docs/mcp/mcp-node) lets a Lamatic flow connect to an existing MC
 
 - *"I want my flow to use tools from an external service via MCP."* → [MCP Node](/docs/mcp/mcp-node)
 - *"I want Claude/Cursor to call my Lamatic flow."* → [Graph MCP](/docs/mcp/graph-mcp)
-- *Both.* → Use them together — a flow that consumes external MCP tools can itself be exposed via Graph MCP.
+- *"I want my AI assistant to answer questions about Lamatic itself."* → [Docs MCP](/docs/mcp/docs-mcp)
+- *Combine them.* → A flow that consumes external MCP tools (MCP Node) can itself be exposed via Graph MCP, while you use Docs MCP to ask your assistant about Lamatic as you build.
 
 ---
 
 ## Related
 
-- [Generate Text Node](/docs/nodes/ai/generate-text-node) — can integrate MCP tools loaded by the MCP Node
-- [Docs MCP](/docs/docs-mcp) — Lamatic's hosted MCP server for querying these docs from any AI assistant
+- [Generate Text Node](/docs/nodes/ai/generate-text-node): can integrate MCP tools loaded by the MCP Node

--- a/pages/docs/mcp/mcp-node.mdx
+++ b/pages/docs/mcp/mcp-node.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP Node
-description: Connect Lamatic flows to external MCP servers — securely access third-party data sources and tools through the Model Context Protocol.
+description: Connect Lamatic flows to external MCP servers. Securely access third-party data sources and tools through the Model Context Protocol.
 ---
 
 # MCP Node

--- a/pages/docs/nodes/ai/classifier-node.mdx
+++ b/pages/docs/nodes/ai/classifier-node.mdx
@@ -85,7 +85,7 @@ Classify this support message and route it to the right department:
 | `Billing` | Payment issues, invoices, failed charges |
 | `Technical` | Bugs, errors, integration problems |
 
-Each classifier becomes a **branch in your flow** — add the next nodes
+Each classifier becomes a **branch in your flow**. Add the next nodes
 (e.g. send to Slack, trigger an email) inside each branch.
 
 > The Description field helps the LLM decide which branch to pick on ambiguous inputs.

--- a/pages/docs/nodes/data/tables-node.mdx
+++ b/pages/docs/nodes/data/tables-node.mdx
@@ -327,7 +327,7 @@ query: SELECT * FROM your_table WHERE id = 1
 | **Problem**                   | **Solution**                                                                    |
 | ----------------------------- | ------------------------------------------------------------------------------- |
 | **No table appears in list**  | Click the refresh icon next to the Table field to reload available tables.      |
-| **Where Clause not working**  | Ensure a table is selected first — conditions can only be added after selection. |
+| **Where Clause not working**  | Ensure a table is selected first; conditions can only be added after selection. |
 | **Insert fails with no data** | Verify the `Data` field contains a valid JSON object or array.                  |
 | **Query returns no results**  | Check your SQL syntax and confirm the table name and column names are correct.  |
-| **Columns field greyed out**  | Select a table first — column selection is only available after table selection. |
+| **Columns field greyed out**  | Select a table first; column selection is only available after table selection. |

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -191,6 +191,221 @@ We have this interactive Miro board that explains the architecture of Lamatic.ai
 
 ---
 
+# CLI
+
+Source: https://lamatic.ai/docs/cli
+
+# CLI
+
+`@lamatic/cli` is the official command-line interface for managing your Lamatic organization — create projects, manage flows, trigger deployments, configure contexts and integrations, all from the terminal.
+
+---
+
+## Installation
+
+Install globally to use the `lamatic` command anywhere:
+
+```bash
+npm install -g @lamatic/cli
+```
+
+Or run on demand without installing:
+
+```bash
+npx @lamatic/cli <command>
+```
+
+---
+
+## Authentication
+
+Authenticate once with your API key, organization ID, and user ID. Credentials are cached locally so subsequent commands don't require re-entering them.
+
+```bash
+lamatic auth login \
+  --api-key <YOUR_API_KEY> \
+  --org-id <YOUR_ORG_ID> \
+  --user-id <YOUR_USER_ID>
+```
+
+| Command | Description |
+|---|---|
+| `lamatic auth login` | Authenticate with your API key |
+| `lamatic auth status` | Check current auth status |
+| `lamatic auth logout` | Logout and clear credentials |
+
+---
+
+## Help
+
+```bash
+lamatic --help
+lamatic <command> --help
+```
+
+---
+
+## Commands
+
+### Projects
+
+| Command | Description |
+|---|---|
+| `lamatic init <name>` | Create a new Lamatic project |
+| `lamatic project list` | List all projects in your org |
+| `lamatic project get` | Fetch and download a project locally |
+| `lamatic project delete` | Delete a project |
+
+```bash
+# Create a new project
+lamatic init my-project --scratch
+
+# List all projects
+lamatic project list
+
+# Download an existing project locally
+lamatic project get --project-id <PROJECT_ID>
+
+# Delete a project
+lamatic project delete --project-id <PROJECT_ID>
+```
+
+### Flows
+
+| Command | Description |
+|---|---|
+| `lamatic flows create` | Create a new flow in a project |
+| `lamatic flows list` | List all flows in a project |
+| `lamatic flows rename` | Rename a flow |
+| `lamatic flows delete` | Delete a flow |
+| `lamatic flows status` | Update flow status (active/inactive) |
+
+```bash
+# Create a flow
+lamatic flows create --project-id <PROJECT_ID> --name "My Flow"
+
+# List all flows
+lamatic flows list --project-id <PROJECT_ID>
+
+# Rename a flow
+lamatic flows rename --project-id <PROJECT_ID> --flow-id <FLOW_ID> --name "New Name"
+
+# Delete a flow
+lamatic flows delete --project-id <PROJECT_ID> --flow-id <FLOW_ID>
+
+# Update flow status
+lamatic flows status --project-id <PROJECT_ID> --flow-id <FLOW_ID> --status active
+```
+
+### Deployments
+
+| Command | Description |
+|---|---|
+| `lamatic deploy` | Trigger a deployment for a project |
+| `lamatic deployments list` | List all deployments |
+| `lamatic deployments get` | Get details of a specific deployment |
+
+```bash
+# Trigger a deployment
+lamatic deploy --project-id <PROJECT_ID>
+
+# List all deployments
+lamatic deployments list --project-id <PROJECT_ID>
+
+# Get deployment details
+lamatic deployments get --project-id <PROJECT_ID> --deployment-id <DEPLOYMENT_ID>
+```
+
+### Contexts
+
+| Command | Description |
+|---|---|
+| `lamatic contexts list` | List all contexts in a project |
+| `lamatic contexts create` | Create a new context (vector or memory) |
+| `lamatic contexts delete` | Delete a context |
+
+```bash
+# List contexts
+lamatic contexts list --project-id <PROJECT_ID>
+
+# Create a context
+lamatic contexts create --project-id <PROJECT_ID> --name "my-context" --type vector
+
+# Delete a context
+lamatic contexts delete --project-id <PROJECT_ID> --context-id <CONTEXT_ID>
+```
+
+### Models
+
+| Command | Description |
+|---|---|
+| `lamatic models list` | List all model credentials |
+| `lamatic models add` | Add a new model credential |
+
+```bash
+# List model credentials
+lamatic models list --project-id <PROJECT_ID>
+
+# Add a model credential
+lamatic models add --project-id <PROJECT_ID>
+```
+
+### Integrations
+
+| Command | Description |
+|---|---|
+| `lamatic integrations list` | List all integration credentials |
+| `lamatic integrations add` | Add a new integration |
+
+```bash
+# List integrations
+lamatic integrations list --project-id <PROJECT_ID>
+
+# Add an integration
+lamatic integrations add --project-id <PROJECT_ID>
+```
+
+---
+
+## Example Workflow
+
+A typical end-to-end flow — log in, create a project, add a flow, deploy, and verify:
+
+```bash
+# 1. Login
+lamatic auth login --api-key <key> --org-id <org_id> --user-id <user_id>
+
+# 2. Create a new project
+lamatic init my-project --scratch
+
+# 3. List your projects to grab the project ID
+lamatic project list
+
+# 4. Create a flow inside the project
+lamatic flows create --project-id <PROJECT_ID> --name "My Flow"
+
+# 5. Deploy the project
+lamatic deploy --project-id <PROJECT_ID>
+
+# 6. Check deployment status
+lamatic deployments list --project-id <PROJECT_ID>
+
+# 7. Download an existing project locally
+lamatic project get --project-id <PROJECT_ID>
+```
+
+---
+
+## Links
+
+- [npm package](https://www.npmjs.com/package/@lamatic/cli)
+- [API Keys](/docs/api-integration/api-key) — where to find the credentials this CLI uses
+- [SDK](/docs/sdk) — programmatic access from your application code
+- [Graph MCP](/docs/mcp/graph-mcp) — execute deployed flows from any AI assistant
+
+
+---
+
 # Context
 
 Source: https://lamatic.ai/docs/context
@@ -262,7 +477,7 @@ Lamatic integrates **Weaviate**, a powerful vector database, to provide efficien
 
 ---
 
-### Memories (Beta)
+### Memories
 Memory systems offer another approach to providing context, particularly useful for maintaining continuity in conversations and personalizing interactions over time.
 
 #### When to Use Memories
@@ -271,7 +486,7 @@ Memories are particularly valuable in scenarios requiring long-term context rete
 > 🔄 **Pro Tip**: Use memories for long-term user preferences and ongoing conversations.
 
 
-#### Lamatic's Built-in Memories Powered by mem0 ( Beta )
+#### Lamatic's Built-in Memories Powered by mem0
 Lamatic incorporates **mem0**, a cutting-edge memory system, to enhance its context-awareness capabilities. This feature allows the platform to remember and utilize important information across multiple interactions, leading to more personalized and contextually relevant outputs.
 
 > 💡 **Tip**: Leverage mem0 for enhanced personalization and context awareness over time.
@@ -515,153 +730,6 @@ Whether you're a forward-thinking global enterprise aiming to harness the full p
 
 ## Deployment Logs
 To provide you with full transparency and control over your deployment process, we offer detailed deployment logs. These logs allow you to monitor the entire build process, providing a step-by-step breakdown of each stage. This feature is invaluable for troubleshooting, as it allows you to quickly identify and address any errors or issues that may arise during the build and deployment phases, ensuring smooth and efficient application launches.
-
-
----
-
-# Lamatic Docs MCP
-
-Source: https://lamatic.ai/docs/docs-mcp
-
-# Lamatic Docs MCP
-
-> Query Lamatic.ai documentation instantly from any AI assistant — no searching, no tab switching, just answers.
-
----
-
-## What is the Docs MCP?
-
-The **Lamatic Docs MCP** is a [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI assistants like Claude, Cursor, and Windsurf direct access to Lamatic.ai documentation.
-
-It is powered by a RAG pipeline built entirely on Lamatic:
-- **Firecrawl** scrapes the docs
-- **Chunking + Vectorize** indexes them into a VectorDB
-- **RAG Node** answers questions semantically
-- **Next.js + Vercel** exposes the MCP endpoint publicly
-
-<Callout type="info">
-  The MCP is free to use. No API key or account required.
-</Callout>
-
----
-
-## Connect
-
-Add this to your MCP client config:
-
-```json
-{
-  "mcpServers": {
-    "lamatic-docs": {
-      "url": "https://docmcp.lamatic.ai/api/mcp"
-    }
-  }
-}
-```
-
-### Claude Desktop
-
-**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`  
-**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "lamatic-docs": {
-      "url": "https://docmcp.lamatic.ai/api/mcp"
-    }
-  }
-}
-```
-
-Restart Claude Desktop after saving. You should see a 🔌 tools icon in the chat input.
-
-### Cursor / Windsurf / Cline
-
-Add the same config to your MCP settings. Most clients support the `url` field directly for HTTP-based MCP servers.
-
-## Available Tools
-
-### `query_docs`
-
-Ask any question about Lamatic.ai documentation. Uses RAG to search across all indexed docs and return a precise answer with references.
-
-**Input:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `text` | string | ✅ | The question to ask |
-
-**Example:**
-
-```json
-{
-  "name": "query_docs",
-  "arguments": {
-    "text": "How do I set up a RAG node in Lamatic?"
-  }
-}
-```
-
----
-
-## How It Works
-
-```
-Your Question
-      ↓
-MCP Client (Claude / Cursor)
-      ↓
-docmcp.lamatic.ai/mcp/api
-      ↓
-Lamatic RAG Flow
-      ↓
-VectorDB (indexed Lamatic docs)
-      ↓
-Answer
-```
-
-The entire pipeline is built on Lamatic:
-
-1. **Indexing Flow** — scrapes `lamatic.ai/docs` using Firecrawl, chunks content, vectorizes and stores in VectorDB
-2. **Query Flow** — takes your question, runs semantic search, generates answer
-3. **MCP Server** — Next.js API route deployed on Vercel, calls the query flow via GraphQL
-
----
-
-## Supported Clients
-
-| Client | Supported |
-|--------|-----------|
-| Claude Desktop | ✅ |
-| Cursor | ✅ |
-| Windsurf | ✅ |
-| Cline | ✅ |
-| Any HTTP MCP client | ✅ |
-
----
-
-## Source Code
-
-The MCP is open source. You can view, fork, and contribute on GitHub:
-
-[github.com/Lamatic/Lamatic-MCP-Docs](https://github.com/Lamatic/Lamatic-MCP-Docs)
-
-{/*
-<Callout type="tip">
-  Want to build your own Docs MCP for your company? See the [Docs MCP setup guide](/docs/mcp-tools/docs-mcp) — fork the repo, connect your own Lamatic flow, and deploy to Vercel in minutes.
-</Callout>
-*/}
-
----
-
-## Feedback
-
-Found an issue or want to suggest an improvement?
-
-- [Open an issue on GitHub](https://github.com/Lamatic/Lamatic-MCP-Docs/issues)
-- [Join Lamatic Slack](https://lamatic.ai/slack)
-- [Feature board](https://product.lamatic.ai/)
 
 
 ---
@@ -7513,7 +7581,7 @@ In the respective AI Node, add memories under Memories inside Additional Propert
 
 Source: https://lamatic.ai/docs/nodes/data/tables-node
 
-# Tables Node
+# Tables Node(Beta)
 
 
 
@@ -12946,11 +13014,158 @@ The response includes `status` (e.g. `success`) and `result` (your Flow's output
 
 ---
 
+# Lamatic Docs MCP
+
+Source: https://lamatic.ai/docs/mcp/docs-mcp
+
+# Lamatic Docs MCP
+
+> Query Lamatic.ai documentation instantly from any AI assistant — no searching, no tab switching, just answers.
+
+---
+
+## What is the Docs MCP?
+
+The **Lamatic Docs MCP** is a [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI assistants like Claude, Cursor, and Windsurf direct access to Lamatic.ai documentation.
+
+It is powered by a RAG pipeline built entirely on Lamatic:
+- **Firecrawl** scrapes the docs
+- **Chunking + Vectorize** indexes them into a VectorDB
+- **RAG Node** answers questions semantically
+- **Next.js + Vercel** exposes the MCP endpoint publicly
+
+<Callout type="info">
+  The MCP is free to use. No API key or account required.
+</Callout>
+
+---
+
+## Connect
+
+Add this to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "lamatic-docs": {
+      "url": "https://docmcp.lamatic.ai/api/mcp"
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`  
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "lamatic-docs": {
+      "url": "https://docmcp.lamatic.ai/api/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving. You should see a 🔌 tools icon in the chat input.
+
+### Cursor / Windsurf / Cline
+
+Add the same config to your MCP settings. Most clients support the `url` field directly for HTTP-based MCP servers.
+
+## Available Tools
+
+### `query_docs`
+
+Ask any question about Lamatic.ai documentation. Uses RAG to search across all indexed docs and return a precise answer with references.
+
+**Input:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | ✅ | The question to ask |
+
+**Example:**
+
+```json
+{
+  "name": "query_docs",
+  "arguments": {
+    "text": "How do I set up a RAG node in Lamatic?"
+  }
+}
+```
+
+---
+
+## How It Works
+
+```
+Your Question
+      ↓
+MCP Client (Claude / Cursor)
+      ↓
+docmcp.lamatic.ai/mcp/api
+      ↓
+Lamatic RAG Flow
+      ↓
+VectorDB (indexed Lamatic docs)
+      ↓
+Answer
+```
+
+The entire pipeline is built on Lamatic:
+
+1. **Indexing Flow** — scrapes `lamatic.ai/docs` using Firecrawl, chunks content, vectorizes and stores in VectorDB
+2. **Query Flow** — takes your question, runs semantic search, generates answer
+3. **MCP Server** — Next.js API route deployed on Vercel, calls the query flow via GraphQL
+
+---
+
+## Supported Clients
+
+| Client | Supported |
+|--------|-----------|
+| Claude Desktop | ✅ |
+| Cursor | ✅ |
+| Windsurf | ✅ |
+| Cline | ✅ |
+| Any HTTP MCP client | ✅ |
+
+---
+
+## Source Code
+
+The MCP is open source. You can view, fork, and contribute on GitHub:
+
+[github.com/Lamatic/Lamatic-MCP-Docs](https://github.com/Lamatic/Lamatic-MCP-Docs)
+
+{/*
+<Callout type="tip">
+  Want to build your own Docs MCP for your company? See the [Docs MCP setup guide](/docs/mcp-tools/docs-mcp) — fork the repo, connect your own Lamatic flow, and deploy to Vercel in minutes.
+</Callout>
+*/}
+
+---
+
+## Feedback
+
+Found an issue or want to suggest an improvement?
+
+- [Open an issue on GitHub](https://github.com/Lamatic/Lamatic-MCP-Docs/issues)
+- [Join Lamatic Slack](https://lamatic.ai/slack)
+- [Feature board](https://product.lamatic.ai/)
+
+
+---
+
 # Graph MCP
 
 Source: https://lamatic.ai/docs/mcp/graph-mcp
 
-# Graph MCP
+# Graph MCP (Beta)
 
 > Execute your deployed Lamatic flows via AI agents using natural language.
 
@@ -13104,11 +13319,11 @@ Source: https://lamatic.ai/docs/mcp
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard for connecting AI assistants to external systems — data sources, APIs, tools, and services — through a single uniform interface.
 
-Lamatic supports MCP in **two directions**, depending on whether your flow needs to *consume* an MCP server or *act as* one.
+Lamatic ships **three MCP-related products**, each solving a different direction of the protocol.
 
 ---
 
-## The two MCPs
+## The three MCPs
 
 ### MCP Node — consume external MCP servers
 
@@ -13122,19 +13337,25 @@ The [MCP Node](/docs/mcp/mcp-node) lets a Lamatic flow connect to an existing MC
 
 **Use it when:** you want an external AI assistant to drive your Lamatic flows — for example, a developer using Cursor to trigger a flow that generates a report.
 
+### Docs MCP — query Lamatic docs from any AI assistant
+
+[Docs MCP](/docs/mcp/docs-mcp) is a hosted MCP server maintained by Lamatic. It indexes [lamatic.ai/docs](https://lamatic.ai/docs) into a RAG pipeline and exposes a `query_docs` tool so any MCP client can ask natural-language questions about Lamatic and get answers with references — no setup, no API key.
+
+**Use it when:** you want your AI assistant to answer questions about Lamatic itself — its nodes, agents, integrations, error messages — instead of searching the docs manually.
+
 ---
 
 ## When to use which
 
-| | MCP Node | Graph MCP |
-|---|---|---|
-| **Direction** | Lamatic flow → external MCP server | External MCP client → Lamatic flow |
-| **Role** | Client / consumer | Server / provider |
-| **What you provide** | The URL of an external MCP server | A deployed flow with an API trigger |
-| **What you get** | External tools available inside the flow | Your flow callable from any MCP client |
-| **Typical caller** | AI nodes in your flow | Claude Desktop, Cursor, VS Code, custom agents |
-| **Auth model** | Headers / API keys you configure on the node | Org API key + Project API key |
-| **Setup location** | Studio → MCP/Tools → MCP | `npx @lamatic/graph-mcp` in the client's config |
+|                      | MCP Node                                       | Graph MCP                                      | Docs MCP                                                     |
+| -------------------- | ---------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
+| **Direction**        | Lamatic flow → external MCP server             | External MCP client → Lamatic flow             | External MCP client → Lamatic's hosted docs server           |
+| **Role**             | Client / consumer                              | Server / provider                              | Server / provider (hosted by Lamatic)                        |
+| **What you provide** | The URL of an external MCP server              | A deployed flow with an API trigger            | Nothing — it's hosted                                        |
+| **What you get**     | External tools available inside the flow       | Your flow callable from any MCP client         | A `query_docs` tool that answers questions about Lamatic     |
+| **Typical caller**   | AI nodes in your flow                          | Claude Desktop, Cursor, VS Code, custom agents | Claude Desktop, Cursor, anyone reading the docs              |
+| **Auth model**       | Headers / API keys you configure on the node   | Org API key + Project API key                  | None — free to use                                           |
+| **Setup location**   | Studio → MCP/Tools → MCP                       | `npx @lamatic/graph-mcp` in the client's config | Add `https://docmcp.lamatic.ai/api/mcp` to your client config |
 
 ---
 
@@ -13142,14 +13363,14 @@ The [MCP Node](/docs/mcp/mcp-node) lets a Lamatic flow connect to an existing MC
 
 - *"I want my flow to use tools from an external service via MCP."* → [MCP Node](/docs/mcp/mcp-node)
 - *"I want Claude/Cursor to call my Lamatic flow."* → [Graph MCP](/docs/mcp/graph-mcp)
-- *Both.* → Use them together — a flow that consumes external MCP tools can itself be exposed via Graph MCP.
+- *"I want my AI assistant to answer questions about Lamatic itself."* → [Docs MCP](/docs/mcp/docs-mcp)
+- *Combine them.* → A flow that consumes external MCP tools (MCP Node) can itself be exposed via Graph MCP, while you use Docs MCP to ask your assistant about Lamatic as you build.
 
 ---
 
 ## Related
 
 - [Generate Text Node](/docs/nodes/ai/generate-text-node) — can integrate MCP tools loaded by the MCP Node
-- [Docs MCP](/docs/docs-mcp) — Lamatic's hosted MCP server for querying these docs from any AI assistant
 
 
 ---

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -8,10 +8,10 @@
 
 - [Agents](https://lamatic.ai/docs/agents): Agents in Lamatic.ai Studio
 - [Architecture](https://lamatic.ai/docs/architecture): How does Lamatic work?
+- [CLI](https://lamatic.ai/docs/cli): The official Lamatic CLI for managing projects, flows, deployments, contexts, models, and integrations from the terminal.
 - [Context](https://lamatic.ai/docs/context): Context in Lamatic Studio
 - [Contributing](https://lamatic.ai/docs/contributing): Contributing to Lamatic.ai Documentation
 - [Edge Deployment](https://lamatic.ai/docs/deployments): Edge Deployment in Lamatic.ai
-- [Lamatic Docs MCP](https://lamatic.ai/docs/docs-mcp): Query Lamatic.ai documentation instantly using AI — powered by RAG and Model Context Protocol.
 - [Environments](https://lamatic.ai/docs/environment): Create and manage different environments for your flows using branching and merging in Lamatic AI.
 - [Error Codes](https://lamatic.ai/docs/error-reference): Reference for error codes, HTTP status codes, and how to fix common API and Flow failures.
 - [Feedback API](https://lamatic.ai/docs/feedback-api): Collect feedback from any flows, specifically GraphQL APIs, to improve your AI applications.
@@ -153,8 +153,9 @@
 
 ## Mcp
 
+- [Lamatic Docs MCP](https://lamatic.ai/docs/mcp/docs-mcp): Query Lamatic.ai documentation instantly using AI — powered by RAG and Model Context Protocol.
 - [Graph MCP](https://lamatic.ai/docs/mcp/graph-mcp): Execute your deployed Lamatic flows via AI agents using natural language.
-- [MCP Overview](https://lamatic.ai/docs/mcp): Overview of Lamatic's Model Context Protocol (MCP) offerings — MCP Node for consuming external MCP servers, and Graph MCP for exposing your flows as tools.
+- [MCP Overview](https://lamatic.ai/docs/mcp): Overview of Lamatic's Model Context Protocol (MCP) offerings — MCP Node for consuming external servers, Graph MCP for exposing your flows, and Docs MCP for querying Lamatic documentation from any AI assistant.
 - [MCP Node](https://lamatic.ai/docs/mcp/mcp-node): Connect Lamatic flows to external MCP servers — securely access third-party data sources and tools through the Model Context Protocol.
 
 ## Sdk


### PR DESCRIPTION
Added CLI docs, removed Beta from Memories, shifted Doc MCP under MCP heading and removed unnecessary em dashes "-" from some pages. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **New CLI documentation page** (`pages/docs/cli.mdx`): Comprehensive Lamatic CLI guide covering installation, authentication, command reference (Projects, Flows, Deployments, Contexts, Models, Integrations), and an end-to-end example workflow
- **Reorganized MCP documentation**: Moved Docs MCP under the MCP section via navigation updates in `pages/docs/_meta.ts` and `pages/docs/mcp/_meta.ts`, with permanent redirect added to `next.config.mjs`
- **Removed "Beta" designation** from Memories section in `pages/docs/context.mdx`
- **Updated MCP overview** (`pages/docs/mcp/index.mdx`): Now presents three MCP products (MCP Node, Graph MCP, Docs MCP) instead of two, with updated comparison table and guidance
- **Formatting cleanup**: Replaced em dashes with colons or periods throughout documentation files for improved readability
- **Updated documentation bundles**: Synchronized changes in `public/llms-full.txt` and `public/llms.txt` to reflect all documentation updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->