### PR TITLE
Docs: Fix grammer and add skill.md

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -706,7 +706,7 @@ const rewrites = [
   ["/.well-known", "/public/.well-known"],
   ["/robots.txt", "/public/robots.txt"],
     [
-      "/:path((?!docs|blog|guides|integrations|agentkits|templates|company|_next|public|assets|images|api|robots.txt|sitemap-0.xml|llms.txt|llms-full.txt|ambassadors).*)",
+      "/:path((?!docs|blog|guides|integrations|agentkits|templates|company|_next|public|assets|images|api|robots.txt|sitemap-0.xml|llms.txt|llms-full.txt|skill.md|\\.well-known|ambassadors).*)",
       "https://get.lamatic.ai/:path*",
     ],
 ];

--- a/pages/api/md-src/[...path].ts
+++ b/pages/api/md-src/[...path].ts
@@ -87,7 +87,13 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const raw = fs.readFileSync(sourcePath, "utf-8");
   const cleaned = cleanContent(raw);
 
+  // Prepend the llms.txt directive so AI agents that fetch the markdown
+  // version of any page can discover the full documentation index.
+  const llmsDirective =
+    "> For the complete documentation index, see [llms.txt](https://lamatic.ai/llms.txt).\n\n";
+  const body = llmsDirective + cleaned;
+
   res.setHeader("Content-Type", "text/markdown; charset=utf-8");
   res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=3600");
-  res.status(200).send(cleaned);
+  res.status(200).send(body);
 }

--- a/pages/docs/cli.mdx
+++ b/pages/docs/cli.mdx
@@ -5,7 +5,7 @@ description: The official Lamatic CLI for managing projects, flows, deployments,
 
 import { Callout } from "nextra/components";
 
-# CLI
+# Lamatic CLI (Beta)
 
 `@lamatic/cli` is the official command-line interface for managing your Lamatic organization. Create projects, manage flows, trigger deployments, and configure contexts and integrations, all from the terminal.
 

--- a/pages/docs/mcp/index.mdx
+++ b/pages/docs/mcp/index.mdx
@@ -1,13 +1,17 @@
 ---
 title: MCP Overview
-description: Overview of Lamatic's Model Context Protocol (MCP) offerings. MCP Node consumes external servers, Graph MCP exposes your flows, and Docs MCP lets you query Lamatic documentation from any AI assistant.
+description: Overview of Lamatic's three MCP products. MCP Node consumes external servers, Graph MCP exposes your flows, and Docs MCP answers questions about Lamatic from any AI assistant.
 ---
 
 # MCP in Lamatic
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard for connecting AI assistants to external systems (data sources, APIs, tools, services) through a single uniform interface.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard for connecting AI assistants to external systems, data sources, APIs, tools, and services through one uniform interface.
 
-Lamatic ships **three MCP-related products**, each solving a different direction of the protocol.
+Lamatic ships three MCP products, each covering a different direction of the protocol:
+
+- **[MCP Node](/docs/mcp/mcp-node)** lets your flow consume tools from any external MCP server.
+- **[Graph MCP](/docs/mcp/graph-mcp)** exposes your deployed flows as MCP tools that external AI assistants can call.
+- **[Docs MCP](/docs/mcp/docs-mcp)** is a hosted MCP server that answers questions about Lamatic itself.
 
 ---
 
@@ -15,47 +19,41 @@ Lamatic ships **three MCP-related products**, each solving a different direction
 
 ### MCP Node: consume external MCP servers
 
-The [MCP Node](/docs/mcp/mcp-node) lets a Lamatic flow connect to an existing MCP server and use its tools and data from inside your flow. You configure the server URL, headers, and protocol once; the node makes those tools available to any AI node downstream.
+The [MCP Node](/docs/mcp/mcp-node) connects your Lamatic flow to an existing MCP server. Configure the server's URL, headers, and protocol once, and any AI node downstream can call the tools that server exposes.
 
-**Use it when:** you want your flow to talk to a third-party MCP server (e.g. a weather API, a database, an internal tool catalog) and have the AI nodes inside the flow call those tools.
+**Use it when** you want your flow to call a third-party MCP server, such as a weather API, a database, or an internal tool catalog.
 
 ### Graph MCP: expose your flows as MCP tools
 
-[Graph MCP](/docs/mcp/graph-mcp) is the inverse. It turns your deployed Lamatic flows into MCP-callable tools so any MCP client (Claude Desktop, Cursor, VS Code, etc.) can invoke them with natural language.
+[Graph MCP](/docs/mcp/graph-mcp) runs in the opposite direction: it turns your deployed Lamatic flows into MCP-callable tools. Any MCP client (Claude Desktop, Cursor, VS Code, custom agents) can then invoke those flows with natural language.
 
-**Use it when:** you want an external AI assistant to drive your Lamatic flows. For example, a developer using Cursor to trigger a flow that generates a report.
+**Use it when** you want an external AI assistant to drive your flows. For example, a developer in Cursor triggering a flow that generates a weekly report.
 
 ### Docs MCP: query Lamatic docs from any AI assistant
 
-[Docs MCP](/docs/mcp/docs-mcp) is a hosted MCP server maintained by Lamatic. It indexes [lamatic.ai/docs](https://lamatic.ai/docs) into a RAG pipeline and exposes a `query_docs` tool so any MCP client can ask natural-language questions about Lamatic and get answers with references. No setup, no API key.
+[Docs MCP](/docs/mcp/docs-mcp) is a hosted MCP server that Lamatic maintains. It indexes [lamatic.ai/docs](https://lamatic.ai/docs) into a RAG pipeline and exposes a `query_docs` tool. Any MCP client can ask natural-language questions about Lamatic and get answers with references. No setup, no API key.
 
-**Use it when:** you want your AI assistant to answer questions about Lamatic itself (its nodes, agents, integrations, error messages) instead of searching the docs manually.
+**Use it when** you want your AI assistant to answer questions about Lamatic itself its nodes, agents, integrations and error messages, instead of you searching the docs manually.
 
 ---
 
 ## When to use which
 
-|                      | MCP Node                                       | Graph MCP                                      | Docs MCP                                                     |
-| -------------------- | ---------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
-| **Direction**        | Lamatic flow → external MCP server             | External MCP client → Lamatic flow             | External MCP client → Lamatic's hosted docs server           |
-| **Role**             | Client / consumer                              | Server / provider                              | Server / provider (hosted by Lamatic)                        |
-| **What you provide** | The URL of an external MCP server              | A deployed flow with an API trigger            | Nothing (it's hosted)                                        |
-| **What you get**     | External tools available inside the flow       | Your flow callable from any MCP client         | A `query_docs` tool that answers questions about Lamatic     |
-| **Typical caller**   | AI nodes in your flow                          | Claude Desktop, Cursor, VS Code, custom agents | Claude Desktop, Cursor, anyone reading the docs              |
-| **Auth model**       | Headers / API keys you configure on the node   | Org API key + Project API key                  | None (free to use)                                           |
-| **Setup location**   | Studio → MCP/Tools → MCP                       | `npx @lamatic/graph-mcp` in the client's config | Add `https://docmcp.lamatic.ai/api/mcp` to your client config |
+|                      | MCP Node                                        | Graph MCP                                       | Docs MCP                                                      |
+| -------------------- | ----------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------- |
+| **Direction**        | Lamatic flow → external MCP server              | External MCP client → Lamatic flow              | External MCP client → Lamatic-hosted docs server              |
+| **Role**             | Client (consumer)                               | Server (provider)                               | Server (hosted by Lamatic)                                    |
+| **What you provide** | The URL of an external MCP server               | A deployed flow with an API trigger             | Nothing — it's hosted                                         |
+| **What you get**     | External tools available inside the flow        | Your flow callable from any MCP client          | A `query_docs` tool that answers questions about Lamatic      |
+| **Typical caller**   | AI nodes inside your flow                       | Claude Desktop, Cursor, VS Code, custom agents  | Claude Desktop, Cursor, anyone reading the docs               |
+| **Auth model**       | Headers and API keys you set on the node        | Org API key + Project API key                   | None (free to use)                                            |
+| **Setup location**   | Studio → MCP/Tools → MCP                        | `npx @lamatic/graph-mcp` in the client's config | Add `https://docmcp.lamatic.ai/api/mcp` to your client config |
 
 ---
 
 ## Quick chooser
 
-- *"I want my flow to use tools from an external service via MCP."* → [MCP Node](/docs/mcp/mcp-node)
-- *"I want Claude/Cursor to call my Lamatic flow."* → [Graph MCP](/docs/mcp/graph-mcp)
-- *"I want my AI assistant to answer questions about Lamatic itself."* → [Docs MCP](/docs/mcp/docs-mcp)
-- *Combine them.* → A flow that consumes external MCP tools (MCP Node) can itself be exposed via Graph MCP, while you use Docs MCP to ask your assistant about Lamatic as you build.
-
----
-
-## Related
-
-- [Generate Text Node](/docs/nodes/ai/generate-text-node): can integrate MCP tools loaded by the MCP Node
+- "I want my flow to use tools from an external service via MCP." → [MCP Node](/docs/mcp/mcp-node)
+- "I want Claude or Cursor to call my Lamatic flow." → [Graph MCP](/docs/mcp/graph-mcp)
+- "I want my AI assistant to answer questions about Lamatic itself." → [Docs MCP](/docs/mcp/docs-mcp)
+- All of the above. → A flow that consumes external MCP tools (MCP Node) can itself be exposed via Graph MCP, while you use Docs MCP to ask your assistant about Lamatic as you build.

--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://modelcontextprotocol.io/schemas/mcp-discovery.json",
+  "name": "Lamatic.ai",
+  "description": "Discoverable Model Context Protocol servers maintained by Lamatic.",
+  "documentation": "https://lamatic.ai/docs/mcp",
+  "mcpServers": {
+    "lamatic-docs": {
+      "url": "https://docmcp.lamatic.ai/api/mcp",
+      "name": "Lamatic Docs MCP",
+      "description": "Query Lamatic documentation via natural language. Free, hosted, no API key required.",
+      "transport": "http",
+      "authentication": "none",
+      "docs": "https://lamatic.ai/docs/mcp/docs-mcp"
+    },
+    "lamatic-graph": {
+      "package": "@lamatic/graph-mcp",
+      "name": "Lamatic Graph MCP",
+      "description": "Execute deployed Lamatic flows as MCP tools from any client. Requires Lamatic org and project API keys.",
+      "transport": "stdio",
+      "authentication": "api-key",
+      "docs": "https://lamatic.ai/docs/mcp/graph-mcp"
+    }
+  }
+}

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -8,7 +8,7 @@ Concatenated source of every documentation page. Each page is preceded by its so
 
 # Agents
 
-Source: https://lamatic.ai/docs/agents
+Source: https://lamatic.ai/docs/agents.md
 
 # Lamatic Agents
 
@@ -93,7 +93,7 @@ By leveraging these agent types effectively, you can build powerful AI-driven ap
 
 # Architecture
 
-Source: https://lamatic.ai/docs/architecture
+Source: https://lamatic.ai/docs/architecture.md
 
 # Architecture
 <Callout>
@@ -122,6 +122,7 @@ These following steps highlight the typical execution of steps involved in build
     The green shaded area is where the private  information of organisation is stored and processed. Lamatic can be customized
     to host this data on premise or on a private cloud. This ensures that the data is not shared with any third party and is
     completely secure.
+
 
 ## Layers
 ![Architecture diagram](./concepts/img/arch-diagram.jpg)
@@ -176,6 +177,8 @@ This holds all the code logic that enables the reliable execution of our GraphQL
 - **A/B Module** - Perform optimization across Agents, Rules, and Models.
 - **Model Relay** - Managed connections across multiple models.
 
+
+
 ### Model Integration
 
 Integration with third-party models and APIs.
@@ -188,13 +191,13 @@ We have this interactive Miro board that explains the architecture of Lamatic.ai
 
 ---
 
-# CLI
+# Lamatic CLI (Beta)
 
-Source: https://lamatic.ai/docs/cli
+Source: https://lamatic.ai/docs/cli.md
 
-# CLI
+# Lamatic CLI (Beta)
 
-`@lamatic/cli` is the official command-line interface for managing your Lamatic organization — create projects, manage flows, trigger deployments, configure contexts and integrations, all from the terminal.
+`@lamatic/cli` is the official command-line interface for managing your Lamatic organization. Create projects, manage flows, trigger deployments, and configure contexts and integrations, all from the terminal.
 
 ---
 
@@ -366,7 +369,7 @@ lamatic integrations add --project-id <PROJECT_ID>
 
 ## Example Workflow
 
-A typical end-to-end flow — log in, create a project, add a flow, deploy, and verify:
+A typical end-to-end flow: log in, create a project, add a flow, deploy, and verify.
 
 ```bash
 # 1. Login
@@ -396,16 +399,16 @@ lamatic project get --project-id <PROJECT_ID>
 ## Links
 
 - [npm package](https://www.npmjs.com/package/@lamatic/cli)
-- [API Keys](/docs/api-integration/api-key) — where to find the credentials this CLI uses
-- [SDK](/docs/sdk) — programmatic access from your application code
-- [Graph MCP](/docs/mcp/graph-mcp) — execute deployed flows from any AI assistant
+- [API Keys](/docs/api-integration/api-key): where to find the credentials this CLI uses
+- [SDK](/docs/sdk): programmatic access from your application code
+- [Graph MCP](/docs/mcp/graph-mcp): execute deployed flows from any AI assistant
 
 
 ---
 
 # Context
 
-Source: https://lamatic.ai/docs/context
+Source: https://lamatic.ai/docs/context.md
 
 # Context in Lamatic
 
@@ -447,6 +450,8 @@ Context refers to additional information provided to a Large Language Model duri
 ### Direct Prompt Inclusion
 The simplest method involves incorporating relevant information directly into the prompt. However, this approach has limitations due to LLMs' context limits.
 
+
+
 ### Retrieval using Vector Databases
 Vector databases are a powerful solution for context-related challenges in AI. They store and retrieve information based on semantic meaning, allowing for more nuanced and relevant context retrieval.
 
@@ -457,10 +462,13 @@ Vectors in this context are mathematical representations of words, phrases, or e
 
 > **Quick Fact**: Vectors enable semantic searches, making them highly effective for contextual queries.
 
+
 #### When to Use Vector Databases
 Vector databases are particularly useful when dealing with large amounts of unstructured data, such as documents, articles, or product descriptions. They excel in scenarios where semantic similarity is more important than exact keyword matching, making them ideal for providing relevant context to LLMs.
 
 > **Best Practice**: Use vector databases for unstructured data retrieval when accuracy based on meaning is essential.
+
+
 
 #### Lamatic's Built-in Vector Database Powered by Weaviate
 Lamatic integrates **Weaviate**, a powerful vector database, to provide efficient and accurate context retrieval. This integration allows users to leverage the benefits of vector-based search and retrieval without the need for complex setup or management.
@@ -476,6 +484,7 @@ Memory systems offer another approach to providing context, particularly useful 
 Memories are particularly valuable in scenarios requiring long-term context retention, such as ongoing customer support interactions, personalized tutoring, or any application where user preferences and history play a crucial role in generating appropriate responses.
 
 > **Pro Tip**: Use memories for long-term user preferences and ongoing conversations.
+
 
 #### Lamatic's Built-in Memories Powered by mem0
 Lamatic incorporates **mem0**, a cutting-edge memory system, to enhance its context-awareness capabilities. This feature allows the platform to remember and utilize important information across multiple interactions, leading to more personalized and contextually relevant outputs.
@@ -525,7 +534,7 @@ Agent-based systems can utilize various tools to gather and process context. The
 
 # Contributing
 
-Source: https://lamatic.ai/docs/contributing
+Source: https://lamatic.ai/docs/contributing.md
 
 # Contributing to Lamatic.ai Documentation
 
@@ -676,7 +685,7 @@ Thank you for contributing to Lamatic.ai documentation! Your efforts are greatly
 
 # Edge Deployment
 
-Source: https://lamatic.ai/docs/deployments
+Source: https://lamatic.ai/docs/deployments.md
 
 # Edge Deployment
 ![img_5.png](./img/deploy.png)
@@ -695,6 +704,7 @@ Edge deployment is an innovative approach to running applications and services t
 ![Edge Locations](https://miro.medium.com/v2/resize:fit:1400/0*ppjQ6XBDcjcI7w2o.png)
 
 > **Built on Cloudflare**: Our cutting-edge infrastructure leverages Enterprise-grade Cloudflare Workers for optimal performance and reliability. For organizations requiring on-premise solutions or custom network deployments tailored to specific needs, we invite you to reach out to our dedicated team at [hello@lamatic.ai](mailto:hello@lamatic.ai). We're here to provide personalized solutions that align with your unique requirements.
+
 
 ---
 
@@ -726,7 +736,7 @@ To provide you with full transparency and control over your deployment process, 
 
 # Environments
 
-Source: https://lamatic.ai/docs/environment
+Source: https://lamatic.ai/docs/environment.md
 
 # Environments in Lamatic AI
 
@@ -813,7 +823,7 @@ This ensures your environment stays up-to-date with the latest changes from anot
 
 # Error Codes
 
-Source: https://lamatic.ai/docs/error-reference
+Source: https://lamatic.ai/docs/error-reference.md
 
 # Error Reference
 
@@ -887,7 +897,7 @@ If the request succeeds but the Flow run fails (e.g. a node errors):
 
 # Feedback API
 
-Source: https://lamatic.ai/docs/feedback-api
+Source: https://lamatic.ai/docs/feedback-api.md
 
 # Feedback API
 ![img_9.png](./img/feedback.png)
@@ -1137,7 +1147,7 @@ This data helps you identify areas for improvement and track the quality of your
 
 # Flow Integration
 
-Source: https://lamatic.ai/docs/flow-integration
+Source: https://lamatic.ai/docs/flow-integration.md
 
 # Flow Integration
 
@@ -1314,7 +1324,7 @@ Replace `your-project-api-key` with your actual API key from **Get API Key** in 
 
 # Flows
 
-Source: https://lamatic.ai/docs/flows
+Source: https://lamatic.ai/docs/flows.md
 
 # Lamatic Flows
 
@@ -1418,6 +1428,8 @@ The **Share Flow** feature in Lamatic.ai allows users to collaborate, distribute
 
 This feature enhances workflow management, enabling better collaboration and efficiency in building AI-powered solutions.
 
+
+
 ## Best Practices
 
 - **Clear Goal:** Design each flow with a specific objective.
@@ -1443,7 +1455,7 @@ By mastering these elements, you’ll be equipped to build robust, efficient flo
 
 # Quickstart Guide
 
-Source: https://lamatic.ai/docs/get-started
+Source: https://lamatic.ai/docs/get-started.md
 
 # Quickstart Guide
 
@@ -1612,7 +1624,7 @@ See [API & SDK](/docs/sdk) and [GraphQL](/docs/interface/graphql) for full examp
 
 # Glossary
 
-Source: https://lamatic.ai/docs/glossary
+Source: https://lamatic.ai/docs/glossary.md
 
 # Glossary
 
@@ -1764,7 +1776,7 @@ A unique identifier for a specific Flow. You'll need this when triggering a Flow
 
 # IDE
 
-Source: https://lamatic.ai/docs/ide
+Source: https://lamatic.ai/docs/ide.md
 
 # IDE (Integrated Development Environment) in Lamatic
 In Lamatic, the IDE refers to the built-in interactive tools that help you easily build, debug, and optimize flows within the platform. Similar to traditional code IDEs, Lamatic's IDE provides a comprehensive environment for creating and managing flows efficiently.
@@ -1774,6 +1786,7 @@ Lamatic offers three specialized IDEs to cater to different aspects of flow deve
 1. Prompt IDE
 2. Code IDE
 3. GraphQL IDE
+
 
 ## Current Capabilities
 
@@ -1790,11 +1803,12 @@ Lamatic offers three specialized IDEs to cater to different aspects of flow deve
 
 # Overview
 
-Source: https://lamatic.ai/docs
+Source: https://lamatic.ai/docs.md
 
 # Overview
 
 > Lamatic is a collaborative Agentic AI Development Platform that helps cross-functional teams collaboratively develop, monitor, and optimize their GenAI applications.
+
 
 ---
 
@@ -1830,6 +1844,7 @@ Monitor, analyze and optimize your AI applications.
 - [Reports](/docs/reports) — Analyze your projects with intuitive charts and queries.
 - [API & SDK](/docs/sdk) — Integrate and interact with your Flows programmatically.
 
+
 ## Get Started
 
 <Cards num={3}>
@@ -1843,6 +1858,7 @@ Monitor, analyze and optimize your AI applications.
         {/*![Quickstart icon (rocket)]()*/}
     </Card>
 </Cards>
+
 
 ## Updates
 
@@ -1870,12 +1886,14 @@ Learn more about ways to get in touch on our [Support](https://support.lamatic.a
 
 # Interfaces
 
-Source: https://lamatic.ai/docs/interface
+Source: https://lamatic.ai/docs/interface.md
 
 # Interfaces for Integrating AI Features
 After your project is deployed and your flows are passing tests, these interfaces are the ways you plug Lamatic into real products and channels.
 
 Interfaces provide various options to seamlessly integrate and embed AI features into your application. These interfaces offer flexibility and power, allowing you to harness the full potential of AI within your project. Once your project is deployed, you can easily access the automatically generated setup documentation. This documentation is conveniently located within the flow or at the top bar of your project, ensuring you have all the necessary information at your fingertips.
+
+
 
 ## Methods
 ### GraphQL API
@@ -1903,7 +1921,7 @@ The widget solution allows for quick integration of Generative AI features into 
 
 # IP Allowlisting
 
-Source: https://lamatic.ai/docs/ips
+Source: https://lamatic.ai/docs/ips.md
 
 # IP Allowlisting
 
@@ -2048,7 +2066,7 @@ Lamatic edge traffic can also originate from Cloudflare worker infrastructure. I
 
 # Jobs
 
-Source: https://lamatic.ai/docs/jobs
+Source: https://lamatic.ai/docs/jobs.md
 
 # Automated Data Synchronization and Scheduled Processes in Flows
 ![img_8.png](./img/jobs.png)
@@ -2106,7 +2124,7 @@ To address records in failed requests, you should adjust the Sync Mode to **Full
 
 # Logs
 
-Source: https://lamatic.ai/docs/logs
+Source: https://lamatic.ai/docs/logs.md
 
 # Logs: Monitoring and Analyzing Requests in Real Time
 ![logs.png](./img/logs.png)
@@ -2172,7 +2190,7 @@ The Export feature allows users to download the filtered or complete log data in
 
 # Models
 
-Source: https://lamatic.ai/docs/models
+Source: https://lamatic.ai/docs/models.md
 
 # Models in Generative AI Projects
 
@@ -2289,7 +2307,7 @@ Lamatic offers a convenient feature that allows you to establish default models 
 
 # Nodes
 
-Source: https://lamatic.ai/docs/nodes
+Source: https://lamatic.ai/docs/nodes.md
 
 # Nodes
 
@@ -2353,7 +2371,7 @@ Not sure what to pick? Start from your trigger and ask: “what’s the next ste
 
 # Reports
 
-Source: https://lamatic.ai/docs/reports
+Source: https://lamatic.ai/docs/reports.md
 
 # Reports
 
@@ -2421,15 +2439,17 @@ Use this dashboard to:
 
 # Templates
 
-Source: https://lamatic.ai/docs/templates
+Source: https://lamatic.ai/docs/templates.md
 
 # Templates in Lamatic
 
 ![img_13.png](./img/template.png)
 
+
 Templates in Lamatic provide a streamlined way to create flows using pre-configured node sets, reducing the need for manual setup. This guide covers key processes for using templates effectively.
 
 ## Creating a New Flow from a Template
+
 
 To create a flow using a template in Lamatic Studio:
 
@@ -2439,6 +2459,7 @@ To create a flow using a template in Lamatic Studio:
 - Complete all required fields within the template.
 - Test the flow thoroughly to ensure it works as expected.
 - Once verified, deploy your flow.
+
 
 ## Sharing Templates
 
@@ -2473,7 +2494,7 @@ Following these steps enables efficient creation, sharing, and publication of te
 
 # Version Control
 
-Source: https://lamatic.ai/docs/version-control
+Source: https://lamatic.ai/docs/version-control.md
 
 # Version Control in Lamatic AI
 
@@ -2542,7 +2563,7 @@ This ensures your branch stays up-to-date with the latest changes from productio
 
 # Vibe Build Overview
 
-Source: https://lamatic.ai/docs/vibe-build
+Source: https://lamatic.ai/docs/vibe-build.md
 
 # Build With Vibe
 
@@ -2599,7 +2620,7 @@ Once deployed, the green `Project Deployed` badge in the header confirms the lat
 
 # AI Middleware
 
-Source: https://lamatic.ai/docs/concepts/ai-middleware
+Source: https://lamatic.ai/docs/concepts/ai-middleware.md
 
 # AI Middleware
 
@@ -2721,7 +2742,7 @@ For a deeper dive into how Lamatic works under the hood, see the [Architecture d
 
 # LLM Prompting Techniques
 
-Source: https://lamatic.ai/docs/concepts/llm-prompting
+Source: https://lamatic.ai/docs/concepts/llm-prompting.md
 
 # LLM Prompting Techniques
 
@@ -2906,7 +2927,7 @@ In Lamatic Studio, you can implement different types of prompts with Dynamic var
 
 # What is Retrieval-Augmented Generation (RAG)?
 
-Source: https://lamatic.ai/docs/concepts/rag
+Source: https://lamatic.ai/docs/concepts/rag.md
 
 # What is Retrieval-Augmented Generation (RAG)?
 
@@ -2978,7 +2999,7 @@ You can explore [guides](/guides) on implementing RAG with Google Drive, S3, and
 
 # Vibe Coding with Lamatic.ai
 
-Source: https://lamatic.ai/docs/concepts/vibe-coding-setup
+Source: https://lamatic.ai/docs/concepts/vibe-coding-setup.md
 
 # Vibe Coding with Lamatic.ai
 
@@ -3060,7 +3081,7 @@ These improvements allow new contributors to **get productive immediately**, red
 
 # Authentication with API Keys
 
-Source: https://lamatic.ai/docs/studio/studio-keys
+Source: https://lamatic.ai/docs/studio/studio-keys.md
 
 # Authentication with API Keys
 
@@ -3386,6 +3407,7 @@ curl -X POST "$PROJECT_URL" \
   </Tabs.Tab>
 </Tabs>
 
+
 ### Understanding the Response
 
 The response structure can be configured in the **Schema** of the GraphQL Response node in your workflow. The response will follow this structure:
@@ -3415,7 +3437,7 @@ The response structure can be configured in the **Schema** of the GraphQL Respon
 
 # Studio Overview
 
-Source: https://lamatic.ai/docs/studio/studio-overview
+Source: https://lamatic.ai/docs/studio/studio-overview.md
 
 # Studio: Command and Control for Lamatic Projects
 
@@ -3568,7 +3590,7 @@ Now that you understand Studio's interface:
 
 # Projects
 
-Source: https://lamatic.ai/docs/studio/studio-project
+Source: https://lamatic.ai/docs/studio/studio-project.md
 
 # Projects
 In the context of Studio, a project represents an individual **GenAI** application you're developing. The workspace structure allows for multiple projects to coexist, each representing a unique GenAI application with its own set of requirements and functionalities. Studio ensures that each project maintains its independence by providing dedicated resources and endpoint controls. This separation is crucial for maintaining the integrity and security of your applications. Even within the same workspace, projects are designed to operate without interference, and they do not share credentials, ensuring that each project remains a self-contained unit with its own secure environment.
@@ -3636,6 +3658,7 @@ As of now, the following developer integrations are available for your Studio pr
 1. **[Langfuse (Beta)](/docs/reports/langfuse-integration)**: Advanced LLM observability and analytics to track, debug, and improve GenAI performance.
 2. **GitHub**: Connect a repository to commit workflow updates for seamless version control and team collaboration.
 
+
 > **Developer Note**: These integrations can help you keep your GenAI project optimized and data-driven.
 
 ---
@@ -3669,7 +3692,7 @@ With Variables and Secrets you can Safeguard your API keys and credentials with 
 
 # Role-Based Access
 
-Source: https://lamatic.ai/docs/studio/studio-role-based-access
+Source: https://lamatic.ai/docs/studio/studio-role-based-access.md
 
 # Role-Based Access Guide
 
@@ -3808,7 +3831,7 @@ Need help? Contact [support@lamatic.ai](mailto:support@lamatic.ai) for assistanc
 
 # Tags
 
-Source: https://lamatic.ai/docs/studio/studio-tags
+Source: https://lamatic.ai/docs/studio/studio-tags.md
 
 # Tags
 
@@ -3883,6 +3906,7 @@ Consider organizing tags into categories:
 - **Limit tag count**: Avoid over-tagging flows; 2-5 relevant tags per flow is usually sufficient.
 - **Document conventions**: Share your tagging conventions with your team to ensure consistency.
 
+
 > **Quick Start**: Start tagging your flows today! Even a simple tagging system with 3-5 common tags can significantly improve your workflow management and accessibility.
 
 
@@ -3890,7 +3914,7 @@ Consider organizing tags into categories:
 
 # Variables & Secrets
 
-Source: https://lamatic.ai/docs/studio/studio-variables-and-secrets
+Source: https://lamatic.ai/docs/studio/studio-variables-and-secrets.md
 
 # Variables & Secrets
 
@@ -3929,7 +3953,7 @@ By utilizing **Variables & Secrets**, you maintain a secure and scalable approac
 
 # Flow Editor
 
-Source: https://lamatic.ai/docs/flows/editor
+Source: https://lamatic.ai/docs/flows/editor.md
 
 # Flow Editor
 
@@ -4087,7 +4111,7 @@ By following these step-by-step methods, you can effectively utilize the Editor 
 
 # Flow AI Assistant
 
-Source: https://lamatic.ai/docs/flows/flow-assistant
+Source: https://lamatic.ai/docs/flows/flow-assistant.md
 
 # Flow AI Assistant
 
@@ -4223,9 +4247,10 @@ The Flow AI Assistant transforms the Flow Editor into a more intuitive and power
 
 # Flow Config
 
-Source: https://lamatic.ai/docs/flows/flow-config
+Source: https://lamatic.ai/docs/flows/flow-config.md
 
 # Flow Config (YAML Format)
+
 
 ![img_6.png](./img/flow-config.png)
 
@@ -4357,7 +4382,7 @@ Each part of the YAML configuration plays a crucial role in defining, structurin
 
 # Node Configuration
 
-Source: https://lamatic.ai/docs/flows/node-config
+Source: https://lamatic.ai/docs/flows/node-config.md
 
 # Node Configuration
 
@@ -4436,7 +4461,7 @@ By effectively using the Config, Schema, and Logs tabs, you can build, configure
 
 # Nodes
 
-Source: https://lamatic.ai/docs/flows/nodes
+Source: https://lamatic.ai/docs/flows/nodes.md
 
 # Nodes in Lamatic
 
@@ -4515,7 +4540,7 @@ Nodes in Lamatic have visual indicators representing their current state:
 
 # Sticky notes
 
-Source: https://lamatic.ai/docs/flows/sticky-notes
+Source: https://lamatic.ai/docs/flows/sticky-notes.md
 
 # Sticky Notes in Lamatic Flows
 
@@ -4547,6 +4572,7 @@ Source: https://lamatic.ai/docs/flows/sticky-notes
    - Use different colors to classify notes (e.g., **yellow for reminders, blue for important updates**).
    - Keep track of changes or comments without needing external documentation.
 
+
 Sticky Notes add a **new layer of flexibility** to Lamatic flow, making it easier than ever to manage and organize complex automation flows.
 
 
@@ -4554,7 +4580,7 @@ Sticky Notes add a **new layer of flexibility** to Lamatic flow, making it easie
 
 # Variables
 
-Source: https://lamatic.ai/docs/flows/variables
+Source: https://lamatic.ai/docs/flows/variables.md
 
 # Understanding Variables in Node-Based Systems
 
@@ -4656,15 +4682,19 @@ output = {
 
 # Classifier Node
 
-Source: https://lamatic.ai/docs/nodes/ai/classifier-node
+Source: https://lamatic.ai/docs/nodes/ai/classifier-node.md
 
 # Classifier Node
+
+
 
 ## Overview
 
 The Classifier Node is a powerful AI component that enables users to automatically categorize and classify data based on predefined criteria or machine learning models. This node is essential for applications requiring intelligent data sorting, sentiment analysis, content moderation, and automated decision-making processes.
 
 ![classifier.png](../img/classifier/classifier.png)
+
+
 
 ## Features
 
@@ -4726,7 +4756,7 @@ Classify this support message and route it to the right department:
 | `Billing` | Payment issues, invoices, failed charges |
 | `Technical` | Bugs, errors, integration problems |
 
-Each classifier becomes a **branch in your flow** — add the next nodes
+Each classifier becomes a **branch in your flow**. Add the next nodes
 (e.g. send to Slack, trigger an email) inside each branch.
 
 > The Description field helps the LLM decide which branch to pick on ambiguous inputs.
@@ -4854,13 +4884,17 @@ nodes:
 
 # Doc Extractor Node
 
-Source: https://lamatic.ai/docs/nodes/ai/doc-extractor
+Source: https://lamatic.ai/docs/nodes/ai/doc-extractor.md
 
 # Doc Extractor Node
+
+
 
 ## Overview
 
 The Doc Extractor node extracts content from a document URL (PDF or image), sends it to a selected LLM, and applies prompt-based instructions during extraction. You can control both the extraction behavior and the final response shape so downstream nodes receive output in the format you need.
+
+
 
 ## Features
 
@@ -5035,15 +5069,19 @@ The node returns extracted content in the format you selected:
 
 # Generate Image Node
 
-Source: https://lamatic.ai/docs/nodes/ai/generate-image-node
+Source: https://lamatic.ai/docs/nodes/ai/generate-image-node.md
 
 # Generate Image Node
+
+
 
 ## Overview
 
 The Generate Image Node is a powerful AI component that creates images from text descriptions using advanced image generation models. This node enables users to generate custom visuals for various applications including content creation, design prototyping, and creative workflows.
 
 ![image-gen.png](../img/imggen/imggen.webp)
+
+
 
 ## Features
 
@@ -5155,15 +5193,19 @@ nodes:
 
 # Generate JSON Node
 
-Source: https://lamatic.ai/docs/nodes/ai/generate-json-node
+Source: https://lamatic.ai/docs/nodes/ai/generate-json-node.md
 
 # Generate JSON Node
+
+
 
 ## Overview
 
 The Generate JSON Node is a specialized AI component that generates structured JSON data based on user input and predefined schemas. This node is particularly useful for applications requiring consistent data structures, API integrations, and automated data formatting.
 
 ![json-gen.png](../img/json/json.webp)
+
+
 
 ## Features
 
@@ -5356,15 +5398,19 @@ nodes:
 
 # Generate Text Node
 
-Source: https://lamatic.ai/docs/nodes/ai/generate-text-node
+Source: https://lamatic.ai/docs/nodes/ai/generate-text-node.md
 
 # Generate Text Node
+
+
 
 ## Overview
 
 The Generate Text node allows users to programmatically generate text outputs by submitting prompts to selected LLMs. These text outputs can be further processed within each flow. This node is particularly useful for applications requiring dynamic text creation, such as chatbots, content creation, and automated report generation.
 
 ![text-gen.png](../img/text-gen/text-llm.webp)
+
+
 
 ## Features
 
@@ -5553,15 +5599,20 @@ nodes:
 
 # MCP Node
 
-Source: https://lamatic.ai/docs/nodes/ai/mcp-node
+Source: https://lamatic.ai/docs/nodes/ai/mcp-node.md
 
 # MCP Node
+
+
 
 ## Overview
 
 The MCP Node enables seamless integration with external data sources, APIs, and tools through the Model Context Protocol (MCP). This node allows AI models to securely access external resources, retrieve real-time data, and execute specific functions in a structured manner. It's particularly useful for applications requiring dynamic data access, real-time information retrieval, and integration with third-party services.
 
+
 ![image-gen.png](../img/mcp/mcp.png)
+
+
 
 ## Features
 
@@ -5792,6 +5843,7 @@ nodes:
 
 - The response generated by the MCP node, which includes the result of the MCP function execution processed through the AI model.
 
+
 ## Troubleshooting
 
 ### Common Issues
@@ -5815,15 +5867,19 @@ nodes:
 
 # Multimodal Node
 
-Source: https://lamatic.ai/docs/nodes/ai/multimodal-node
+Source: https://lamatic.ai/docs/nodes/ai/multimodal-node.md
 
 # Multimodal Node
+
+
 
 ## Overview
 
 The Multimodal Node is an advanced AI component that can process and analyze multiple types of data including text, images, and audio using various AI models. This node enables complex multimodal workflows where different types of input data need to be processed together.
 
 ![Multimodal.png](../img/multimodal/multimodal.webp)
+
+
 
 ## Features
 
@@ -6026,13 +6082,17 @@ nodes:
 
 # RAG Node
 
-Source: https://lamatic.ai/docs/nodes/ai/rag-node
+Source: https://lamatic.ai/docs/nodes/ai/rag-node.md
 
 # RAG Node
+
+
 
 ## Overview
 
 The RAG (Retrieval-Augmented Generation) Node is a sophisticated AI component that combines information retrieval with text generation. It first retrieves relevant information from a knowledge base or vector database, then uses that context to generate more accurate and informed responses.
+
+
 
 The RAG Node generates more relevant responses from a Language Learning Model (LLM) by using Retrieval Augmented Generation (RAG). This approach incorporates additional context retrieved from a vector database to improve the accuracy and relevance of the generated text.
 
@@ -6287,15 +6347,19 @@ nodes:
 
 # Supervisor Node
 
-Source: https://lamatic.ai/docs/nodes/ai/supervisor-node
+Source: https://lamatic.ai/docs/nodes/ai/supervisor-node.md
 
 # Supervisor Node
+
+
 
 ## Overview
 
 The **Supervisor Node** is an advanced AI component that provides oversight and management capabilities for workflow execution. It can monitor the performance of other nodes, make decisions about workflow routing, and ensure quality control throughout the process.
 
 ![Supervisor Node](../img/supervisor/supervisor-node.webp)
+
+
 
 ## Features
 
@@ -6316,6 +6380,7 @@ The **Supervisor Node** is an advanced AI component that provides oversight and 
   4. **User-Centric Design**: Provides a visual representation of multi-agent execution paths.
 
 </details>
+
 
 ## What Can I Build?
 
@@ -6477,14 +6542,18 @@ paths and agents defined in the configuration.
 
 # API Node
 
-Source: https://lamatic.ai/docs/nodes/data/api-node
+Source: https://lamatic.ai/docs/nodes/data/api-node.md
 
 # API Node
+
+
 
 ## Overview
 
 The Lamatic.ai API Node enables users to integrate external REST APIs effortlessly into their flow.
 ![api.png](../img/api/api-node.webp)
+
+
 
 ## Features
 
@@ -6605,15 +6674,18 @@ The data retrieved from the API request.
 
 # Chunking Node
 
-Source: https://lamatic.ai/docs/nodes/data/chunking-node
+Source: https://lamatic.ai/docs/nodes/data/chunking-node.md
 
 # Chunking Node
+
 
 ## Overview
 
 The Chunking Node is a data processing component that breaks down large text documents into smaller, manageable chunks. This is essential for processing large documents with AI models that have token limits, enabling efficient text analysis and processing.
 
 ![chunking.png](../img/chunk/chunk.webp)
+
+
 
 ## Features
 
@@ -6711,15 +6783,19 @@ nodes:
 
 # Extract from File Node
 
-Source: https://lamatic.ai/docs/nodes/data/extract-from-file-node
+Source: https://lamatic.ai/docs/nodes/data/extract-from-file-node.md
 
 # Extract from File Node
+
+
 
 ## Overview
 
 The Extract from File Node is a powerful data extraction component that can process and extract content from various file formats including PDFs, Word documents, text files, and more. This node enables users to convert unstructured file content into structured data for further processing.
 
 ![extract-file.png](../img/file/extract.webp)
+
+
 
 ## Features
 
@@ -7051,15 +7127,19 @@ nodes:
 
 # Hybrid Search Node
 
-Source: https://lamatic.ai/docs/nodes/data/hybrid-search-node
+Source: https://lamatic.ai/docs/nodes/data/hybrid-search-node.md
 
 # Hybrid Search Node
+
 
 ## Overview
 
 The Hybrid Search Node is an advanced search component that combines multiple search strategies including semantic search, keyword search, and other retrieval methods to provide comprehensive and accurate results from vector databases.
 
+
 ![hybrid-search.png](../img/hybrid/hybrid.webp)
+
+
 
 ## Features
 
@@ -7168,6 +7248,7 @@ nodes:
   - **`data`**: A string containing the content or information retrieved for the search result.
   - **`score`** (duplicate at the top level): Same as the one inside `_additional`.
 
+
 ### Example Output
 
 ```json
@@ -7203,15 +7284,19 @@ nodes:
 
 # Keyword Search Node
 
-Source: https://lamatic.ai/docs/nodes/data/keyword-search-node
+Source: https://lamatic.ai/docs/nodes/data/keyword-search-node.md
 
 # Keyword Search Node
+
+
 
 ## Overview
 
 The Keyword Search Node is a search component that performs text-based searches using specific keywords and phrases. This node enables users to find relevant content based on exact keyword matches and text patterns.
 
 ![keyword-search.png](../img/keyword/keyword.webp)
+
+
 
 ## Features
 
@@ -7323,15 +7408,19 @@ nodes:
 
 # Memory Add Node
 
-Source: https://lamatic.ai/docs/nodes/data/memory-add-node
+Source: https://lamatic.ai/docs/nodes/data/memory-add-node.md
 
 # Memory Add Node
+
+
 
 ## Overview
 
 The Memory Add Node is a data storage component that stores and manages information in memory for use across workflow executions. This node enables persistent data storage and retrieval within workflows.
 
 ![memory-add.png](../img/mem-add/mem-add.webp)
+
+
 
 ## Features
 
@@ -7462,15 +7551,19 @@ The Memory Add Node is a data storage component that stores and manages informat
 
 # Memory Retrieve Node
 
-Source: https://lamatic.ai/docs/nodes/data/memory-retrieve-node
+Source: https://lamatic.ai/docs/nodes/data/memory-retrieve-node.md
 
 # Memory Retrieve Node
+
+
 
 ## Overview
 
 The Memory Retrieve Node is a data retrieval component that fetches stored information from memory for use in current workflow executions. This node enables access to previously stored data and context.
 
 ![memory-retrieve.png](../img/memory-retrieve/mem-ret.webp)
+
+
 
 ## Features
 
@@ -7638,9 +7731,11 @@ In the respective AI Node, add memories under Memories inside Additional Propert
 
 # Tables Node
 
-Source: https://lamatic.ai/docs/nodes/data/tables-node
+Source: https://lamatic.ai/docs/nodes/data/tables-node.md
 
 # Tables Node(Beta)
+
+
 
 ## Overview
 
@@ -7649,6 +7744,8 @@ The Tables Node is a structured data management component that performs various 
 The Tables Node uses **SQLite** as its underlying database engine.
 
 ![extract-file.png](../img/file/tables.webp)
+
+
 
 ## Features
 
@@ -7950,25 +8047,29 @@ query: SELECT * FROM your_table WHERE id = 1
 | **Problem**                   | **Solution**                                                                    |
 | ----------------------------- | ------------------------------------------------------------------------------- |
 | **No table appears in list**  | Click the refresh icon next to the Table field to reload available tables.      |
-| **Where Clause not working**  | Ensure a table is selected first — conditions can only be added after selection. |
+| **Where Clause not working**  | Ensure a table is selected first; conditions can only be added after selection. |
 | **Insert fails with no data** | Verify the `Data` field contains a valid JSON object or array.                  |
 | **Query returns no results**  | Check your SQL syntax and confirm the table name and column names are correct.  |
-| **Columns field greyed out**  | Select a table first — column selection is only available after table selection. |
+| **Columns field greyed out**  | Select a table first; column selection is only available after table selection. |
 
 
 ---
 
 # Keyword Search Node
 
-Source: https://lamatic.ai/docs/nodes/data/vector-search-node
+Source: https://lamatic.ai/docs/nodes/data/vector-search-node.md
 
 # Keyword Search Node
+
+
 
 ## Overview
 
 The Keyword Search Node is a search component that performs text-based searches using specific keywords and phrases. This node enables users to find relevant content based on exact keyword matches and text patterns.
 
 ![keyword-search.png](../img/keyword/keyword.webp)
+
+
 
 ## Features
 
@@ -8080,15 +8181,19 @@ nodes:
 
 # VectorDB Node
 
-Source: https://lamatic.ai/docs/nodes/data/vectordb-node
+Source: https://lamatic.ai/docs/nodes/data/vectordb-node.md
 
 # VectorDB Node
+
+
 
 ## Overview
 
 The VectorDB Node is a comprehensive vector database management component that performs various operations including insertion, deletion, updating, and management of vector data. This node provides full control over vector database operations.
 
 ![vector-actions.png](../img/vector/vector-actions.webp)
+
+
 
 ## Features
 
@@ -8310,13 +8415,17 @@ Deletes records matching filter criteria.
 
 # Vectorize Node
 
-Source: https://lamatic.ai/docs/nodes/data/vectorize-node
+Source: https://lamatic.ai/docs/nodes/data/vectorize-node.md
 
 # Vectorize Node
+
+
 
 ## Overview
 
 The Vectorize Node is a data transformation component that converts text data into vector embeddings. These embeddings enable semantic search, similarity comparisons, and other AI-powered applications that require numerical representations of text.
+
+
 
 ## Features
 
@@ -8389,6 +8498,7 @@ The Vectorize Node is a data transformation component that converts text data in
       provider_name: openai
 ```
 
+
 ## Output
 
 - `vectors`: An array of arrays, each containing numerical values representing the vectorized form of the input data.
@@ -8429,13 +8539,17 @@ The Vectorize Node is a data transformation component that converts text data in
 
 # Batch Node
 
-Source: https://lamatic.ai/docs/nodes/logic/batch-node
+Source: https://lamatic.ai/docs/nodes/logic/batch-node.md
 
 # Batch Node
+
+
 
 ## Overview
 
 The Batch Node is similar to the Loop (for loop) Node: it iterates over a **List** or a **Range**. The key difference is that Batch runs iterations **in parallel**, and you can control throughput using a **Concurrency Limit**.
+
+
 
 <Callout type="info">
 Use Batch when you want faster processing (parallelism). Use Loop when you need strict ordering or sequential dependencies between iterations.
@@ -8548,15 +8662,18 @@ By leveraging the Lamatic.ai Batch Node, you can process lists and ranges quickl
 
 # Branch Node
 
-Source: https://lamatic.ai/docs/nodes/logic/branch-node
+Source: https://lamatic.ai/docs/nodes/logic/branch-node.md
 
 # Branch Node
+
 
 ## Overview
 
 The Branch Node is a workflow control component that creates multiple execution paths based on conditions or data routing logic. This node enables complex workflow branching and parallel processing of different data streams.
 
 ![branch.png](../img/branch/branch.webp)
+
+
 
 ## Features
 
@@ -8697,15 +8814,20 @@ nodes:
 
 # Code Node
 
-Source: https://lamatic.ai/docs/nodes/logic/code-node
+Source: https://lamatic.ai/docs/nodes/logic/code-node.md
 
 # Code Node 
+
+
 
 ## Overview
 
 The Code Node is a programming component that allows users to execute custom JavaScript code within workflows. This node enables custom data processing, logic implementation, and integration with external systems through code.
 
 ![code.png](../img/code/code.webp)
+
+
+
 
 <Callout type="info">
  We will expand support to include additional programming languages.
@@ -8809,15 +8931,18 @@ By leveraging the Lamatic.ai Code Node, you can create highly customized, effici
 
 # Condition Node
 
-Source: https://lamatic.ai/docs/nodes/logic/condition-node
+Source: https://lamatic.ai/docs/nodes/logic/condition-node.md
 
 # Condition Node 
+
 
 ## Overview
 
 The Lamatic.ai Condition Node is a versatile component designed to introduce condition logic into your flow. Think of it as the decision-maker for your applications. By evaluating variables and triggers, it determines the next steps in your workflow, enabling a more dynamic and responsive system. Whether you're automating processes, managing data flows, or creating complex logic, this node is the foundation for smarter decision-making.
 
 ![execute.png](../img/condition/condition.webp)
+
+
 
 ## Features
 
@@ -8979,13 +9104,17 @@ The Lamatic.ai Condition Node is a versatile component designed to introduce con
 
 # End Node
 
-Source: https://lamatic.ai/docs/nodes/logic/end-node
+Source: https://lamatic.ai/docs/nodes/logic/end-node.md
 
 # End Node
+
+
 
 ## Overview
 
 The End Node is used to **stop the execution of a flow immediately**. When the flow reaches this node, Lamatic **skips any nodes that would execute after it** and routes execution directly to the **Final Trigger Response** node.
+
+
 
 <Callout type="info">
 Place an End Node on any branch where you want to stop early (for example, after a validation failure or a “no-op” condition). Any nodes connected after the End Node won’t run.
@@ -9069,15 +9198,19 @@ The End Node does not transform data. Its purpose is to **terminate execution** 
 
 # Execute Flow Node
 
-Source: https://lamatic.ai/docs/nodes/logic/execute-flow
+Source: https://lamatic.ai/docs/nodes/logic/execute-flow.md
 
 # Execute Flow Node
+
+
 
 ## Overview
 
 The Execute Flow Node is a workflow orchestration component that allows users to call and execute other workflows from within a current workflow. This node enables modular workflow design and reusability of workflow components.
 
 ![execute-flow.png](../img/execute/execute.webp)
+
+
 
 ## Features
 
@@ -9236,15 +9369,20 @@ Before using the Execute Flow, ensure you have:
 
 # Loop Node
 
-Source: https://lamatic.ai/docs/nodes/logic/loop-node
+Source: https://lamatic.ai/docs/nodes/logic/loop-node.md
 
 # Loop Node
+
+
 
 ## Overview
 
 The Loop Node is a control flow component that enables iterative processing of data by repeating operations on collections or arrays. This node is essential for processing large datasets and implementing repetitive logic in workflows.
 
 ![loop.png](../img/loop-node/loop.webp)
+
+
+
 
 ## Features
 
@@ -9388,6 +9526,7 @@ This feature allows for iterating over results dynamically by replacing the inde
 
 {{forLoopEndNode_271.output.loopOutput[0].hybridSearchNode_299.output.searchResults}}
 
+
 for (let i = 0; i < recipeIngredientsFinal.length; i++) {
   recipeIngredientsFinal[i].ingredientId={{forLoopEndNode_271.output.loopOutput[i].hybridSearchNode_299.output.searchResults[0].ingredientId}}
   //Replace index with whatever index you want
@@ -9429,15 +9568,21 @@ The flow execution logs provide detailed insights into the execution process of 
 
 # Variable Node
 
-Source: https://lamatic.ai/docs/nodes/logic/variable-node
+Source: https://lamatic.ai/docs/nodes/logic/variable-node.md
 
 # Variable Node
+
+
 
 ## Overview
 
 The Variable Node is a data management component that allows users to define and manage variables for storing and manipulating data within workflows. This node enables dynamic data handling and state management across workflow executions.
 
 ![variable.png](../img/variable/variable.png)
+
+
+
+
 
 You can map variables in the Variable Node using a simple interface. Each variable can be assigned a type (e.g., string, number) and a value, which can be a static value or a reference to another node's output.
 
@@ -9572,15 +9717,21 @@ By leveraging the Lamatic.ai Variable Node, you can create highly customized, ef
 
 # Wait Node
 
-Source: https://lamatic.ai/docs/nodes/logic/wait-node
+Source: https://lamatic.ai/docs/nodes/logic/wait-node.md
 
 # Wait Node
+
+
 
 ## Overview
 
 The Wait Node is a timing control component that introduces delays in workflow execution. This node is useful for rate limiting, scheduling, and ensuring proper timing between workflow steps.
 
 ![wait.png](../img/wait/wait-node.webp)
+
+
+
+
 
 ## Features
 
@@ -9685,7 +9836,7 @@ The Wait Node return status (true/false). It simply waits for the configured dur
 
 # Node Assistant
 
-Source: https://lamatic.ai/docs/nodes/node-assistant
+Source: https://lamatic.ai/docs/nodes/node-assistant.md
 
 # Node AI Assistant
 
@@ -9863,7 +10014,7 @@ The Node AI Assistant makes node configuration more intuitive and efficient, hel
 
 # Node Logic
 
-Source: https://lamatic.ai/docs/nodes/node-logic
+Source: https://lamatic.ai/docs/nodes/node-logic.md
 
 # Node Logic
 
@@ -10093,7 +10244,7 @@ To add logic to a node:
 
 # Getting Started with Agents
 
-Source: https://lamatic.ai/docs/agents/getting-started
+Source: https://lamatic.ai/docs/agents/getting-started.md
 
 # Getting Started with Agents  
 
@@ -10116,7 +10267,7 @@ To create an agent via the flow editor :
 
 # JSON Agent
 
-Source: https://lamatic.ai/docs/agents/json-agent
+Source: https://lamatic.ai/docs/agents/json-agent.md
 
 # JSON Agent
 
@@ -10240,7 +10391,7 @@ For full token-detail fields, see the [GraphQL response](/docs/interface/graphql
 
 # Multi Modal Agent
 
-Source: https://lamatic.ai/docs/agents/multi-modal-agent
+Source: https://lamatic.ai/docs/agents/multi-modal-agent.md
 
 # Multi Modal Agent
 The **Multi Modal Agent** is an AI-powered multi modal content generator that creates text and images programmatically based on user-defined prompts and parameters. 
@@ -10248,12 +10399,14 @@ It integrates seamlessly into flow and supports generative AI models like OpenAI
 
 ![Multi Modal Agent](./img/multi-modal-agent.png)
 
+
 ## Why Use the Multi Modal Agent?
 - **AI-Generated Visuals:** Automatically generate images using state-of-the-art models.  
 - **AI Text Generation:** Generate text outputs based on custom prompts.
 - **Customizable Prompts:** Define prompts to create images tailored to specific needs.  
 - **Workflow Integration:** Seamlessly connect content generation to automated processes.  
 - **Flexible Model Selection:** Choose from multiple AI models for diverse visual outputs.  
+
 
 ## Key Features
 <details>
@@ -10276,11 +10429,13 @@ It integrates seamlessly into flow and supports generative AI models like OpenAI
 
 </details>
 
+
 ## What Can I Build?
 - **Automated Social Media Content Creation** – Generate visuals for social media, marketing, and branding.
 - **Personalized Image Recommendations** – Create custom images based on user preferences.
 - **Dynamic Visual Content Generation** – Produce images for e-commerce, advertising, and design.
 - **Interactive Applications** – Develop tools for image-based user interactions and feedback.
+
 
 ## How to Use the Multi Modal Agent?
 ### Creating an Multi Modal Agent via Flow Editor
@@ -10295,6 +10450,7 @@ It integrates seamlessly into flow and supports generative AI models like OpenAI
 2. **Choose Multi Modal Agent** – Select from available agent types.  
 3. **Configure Model & Prompts** – Set up AI credentials and parameters.  
 4. **Deploy & Integrate** – Save and start using the agent in your application.  
+
 
 ## Configuration Options
 | **Parameter**             | **Description**                                                                                                | **Example Value** |
@@ -10312,6 +10468,7 @@ It integrates seamlessly into flow and supports generative AI models like OpenAI
 
 You can save the configuration of any agent by clicking on the `Load Save Config` button and selecting `Save as New`. 
 This will save the configuration of the agent and you can use it later by clicking on the `Load Configuration` button in other agents.
+
 
 ## Low-Code Example
 ```yaml
@@ -10356,7 +10513,7 @@ nodes:
 
 # Supervisor Agent
 
-Source: https://lamatic.ai/docs/agents/supervisor-agent
+Source: https://lamatic.ai/docs/agents/supervisor-agent.md
 
 # Supervisor Agent
 The **Supervisor Agent** is a specialized AI agent in Lamatic.ai designed to manage and coordinate multi-agent flow. It serves as the central hub, collecting input, maintaining structured memory, and orchestrating the execution of sub-agents based on predefined logic. This ensures an efficient, iterative process for dynamic AI-powered applications such as structured decision-making systems and task automation.
@@ -10389,6 +10546,7 @@ The **Supervisor Agent** is a specialized AI agent in Lamatic.ai designed to man
 
 </details>
 
+
 ## How to Use the Supervisor Agent?
 ### Creating a Supervisor Agent via Flow Editor
 1. **Add an Agent Node** - Select **Supervisor Agent** from the node list.  
@@ -10403,6 +10561,7 @@ The **Supervisor Agent** is a specialized AI agent in Lamatic.ai designed to man
 2. **Select Supervisor Agent** - Choose it from the available agent types.  
 3. **Configure Agent Settings** - Adjust memory, iteration limits, and agent paths.  
 4. **Deploy the Agent** - Save and activate it in your workflow.  
+
 
 ## Configuration Options
 | **Parameter**        | **Description**                                             | **Example Value** |
@@ -10465,6 +10624,7 @@ By properly configuring your agent paths, you enable the Supervisor Agent to eff
 
 You can save the configuration of any agent by clicking on the `Load Save Config` button and selecting `Save as New`. 
 This will save the configuration of the agent and you can use it later by clicking on the `Load Configuration` button in other agents.
+
 
 ## Low-Code Example
 ```yaml
@@ -10554,17 +10714,19 @@ paths and agents defined in the configuration.
 
 # Text Agent
 
-Source: https://lamatic.ai/docs/agents/text-agent
+Source: https://lamatic.ai/docs/agents/text-agent.md
 
 # Text Agent
 The **Text Agent** is a generative AI agent that enables users to programmatically create text-based outputs using prompts and selected LLMs. It is ideal for applications requiring dynamic content generation, such as chatbots, content creation, automated reporting, and structured AI responses.
 ![Text Agent](./img/text-agent.png)
+
 
 ## Why Use the Text Agent?
 - **AI-Powered Content Generation:** Automate text creation for various use cases.
 - **Customizable AI Responses:** Define system and user prompts for precise output.
 - **Flexible Model Selection:** Choose from different LLM providers based on your needs.
 - **Seamless Integration:** Connect with flow for automated processing.
+
 
 ## Key Features
 <details>
@@ -10587,11 +10749,13 @@ The **Text Agent** is a generative AI agent that enables users to programmatical
 
 </details>
 
+
 ## What Can I Build?
 - **Automated Content Generation** – AI-powered writing for blogs, social media, and marketing.  
 - **Chatbots & Virtual Assistants** – Dynamic, context-aware conversational agents.  
 - **Automated Reports & Summaries** – AI-driven data analysis and business intelligence reporting.  
 - **Email & Message Drafting** – Smart communication tools for efficiency and personalization.  
+
 
 ## How to Use the Text Agent?
 ### Creating a Text Agent via Flow Editor
@@ -10606,6 +10770,7 @@ The **Text Agent** is a generative AI agent that enables users to programmatical
 2. **Choose Text Agent** – Select from available agent types.  
 3. **Configure Model & Prompts** – Set up LLM credentials and prompt templates.  
 4. **Deploy & Integrate** – Save and start using the agent in your application.  
+
 
 ## Configuration Options
 | **Parameter**             | **Description**                                                                                                | **Example Value** |
@@ -10647,6 +10812,7 @@ This will save the configuration of the agent and you can use it later by clicki
 
 ### `generatedResponse`
 - A string containing the text output generated by the model based on the input prompt.
+
 
 ### Example Output
 
@@ -10691,7 +10857,7 @@ This will save the configuration of the agent and you can use it later by clicki
 
 # Benchmarks
 
-Source: https://lamatic.ai/docs/models/benchmark
+Source: https://lamatic.ai/docs/models/benchmark.md
 
 # Benchmarks
 
@@ -10718,7 +10884,7 @@ Thoroughly vetting model performance allows you to optimize for the criteria tha
 
 # Custom Model Integration
 
-Source: https://lamatic.ai/docs/models/custom-model-integration
+Source: https://lamatic.ai/docs/models/custom-model-integration.md
 
 # Custom Model Integration 
 
@@ -10788,7 +10954,7 @@ If no custom model exists, the platform uses **provider defaults**.
 
 # Model Config
 
-Source: https://lamatic.ai/docs/models/model-config
+Source: https://lamatic.ai/docs/models/model-config.md
 
 # Model Config
 
@@ -10840,7 +11006,7 @@ Model Config play a crucial role in fine-tuning the behavior of Large Language M
 
 # Model Logic
 
-Source: https://lamatic.ai/docs/models/model-logic
+Source: https://lamatic.ai/docs/models/model-logic.md
 
 # Model Logic
 
@@ -11005,7 +11171,7 @@ To add logic to a model node:
 
 # Memory Store
 
-Source: https://lamatic.ai/docs/context/memory-store
+Source: https://lamatic.ai/docs/context/memory-store.md
 
 # Memory Store
 
@@ -11024,6 +11190,7 @@ Lamatic's Memory Store is designed to store and manage contextual information ef
 1. Enterprise Knowledge Management: Retain historical context for collaborative applications.
 1. Developer Customization: Enable developers to define custom schemas for specific use cases.
 
+
 ## Implementation 
 1. **Initialize the Memory Store:** Go to Context and select Create New Memory Store.
 1. **Define a Unique Identifier:** Use a User ID, Session ID, or another unique key to link stored information.
@@ -11037,7 +11204,7 @@ Lamatic's Memory Store is designed to store and manage contextual information ef
 
 # Vector Store
 
-Source: https://lamatic.ai/docs/context/vectordb
+Source: https://lamatic.ai/docs/context/vectordb.md
 
 # Lamatic.ai built in Vector Store
 ![img.png](./img/inbuild.webp)
@@ -11103,6 +11270,7 @@ One of the key features of the Vector Explorer is its ability to run sample sear
 
 The similarity scores are particularly useful for understanding the semantic relationships between your vector objects. By analyzing these scores, you can fine-tune your vector representations, improve your search algorithms, and ultimately enhance the overall performance of your AI applications that rely on this vector data.score.
 
+
 ### Delete record
 You can also remove the records by clicking the delete button.
 ![img.png](./img/inbuild.webp)
@@ -11121,7 +11289,7 @@ Weaviate is a distributed, cloud-native database that can scale horizontally by 
 
 # Mapping and Ingesting Data
 
-Source: https://lamatic.ai/docs/context/vectordb/adding-data
+Source: https://lamatic.ai/docs/context/vectordb/adding-data.md
 
 # **Mapping and Ingesting Data into Weaviate**
 
@@ -11171,7 +11339,7 @@ With [Lamatic.ai](http://lamatic.ai/)'s visual data mapping tools integrated wit
 
 # Code IDE
 
-Source: https://lamatic.ai/docs/ide/code-ide
+Source: https://lamatic.ai/docs/ide/code-ide.md
 
 # Code IDE
 ![Code IDE showing JavaScript editor, variable insertion, and test output panel](./img/code-editor.png)
@@ -11233,7 +11401,7 @@ The Code Assistant makes JavaScript development more accessible, helping both be
 
 # GraphQL Playgrounds IDE
 
-Source: https://lamatic.ai/docs/ide/graphql-ide
+Source: https://lamatic.ai/docs/ide/graphql-ide.md
 
 # GraphQL IDE
 ![img_2.png](./img/gql.png)
@@ -11259,7 +11427,7 @@ The **GraphQL IDE**, powered by GraphiQL, is a powerful tool for interacting wit
 
 # Prompt IDE
 
-Source: https://lamatic.ai/docs/ide/prompt-ide
+Source: https://lamatic.ai/docs/ide/prompt-ide.md
 
 # Prompt IDE
 
@@ -11310,6 +11478,7 @@ The Prompt Assistant makes prompt engineering more accessible, helping both begi
 
 To make your prompts more dynamic and context-aware, you can **insert variables** directly into your prompts. Variables allow you to personalize responses or integrate real-time data into the prompt text.
 ![img_1.png](./img/prompt-var2.png)
+
 
 1. Click **Insert Variable** to add dynamic placeholders.
 2. Choose the data source:
@@ -11369,7 +11538,7 @@ This feature enables seamless integration of reusable prompts, reducing redundan
 
 # Tools
 
-Source: https://lamatic.ai/docs/mcp-tools/tools
+Source: https://lamatic.ai/docs/mcp-tools/tools.md
 
 # Tools
 
@@ -11475,6 +11644,7 @@ To integrate tools into your flow, follow these steps:
 2. Choose either **Generate Text Node** or **Multimodal Node**, then navigate to node config.  
 3. Select the desired tools. You can add multiple tools as needed.  
 
+
 ## Troubleshooting
 
 ### Common Issues
@@ -11494,7 +11664,7 @@ To integrate tools into your flow, follow these steps:
 
 # Code Testing
 
-Source: https://lamatic.ai/docs/tests/code-testing
+Source: https://lamatic.ai/docs/tests/code-testing.md
 
 # Testing Custom Code
 You can test custom logic written in Code Nodes before running the entire flow.
@@ -11525,7 +11695,7 @@ Use this to:
 
 # Flow Debugging
 
-Source: https://lamatic.ai/docs/tests/flow-debugging
+Source: https://lamatic.ai/docs/tests/flow-debugging.md
 
 # Flow Debugging
 ![Flow Testing.png](./img/flow-debug.png)
@@ -11584,7 +11754,7 @@ After running a test:
 
 # Flow Testing
 
-Source: https://lamatic.ai/docs/tests/flow-testing
+Source: https://lamatic.ai/docs/tests/flow-testing.md
 
 # Flow Testing
 
@@ -11602,6 +11772,7 @@ Lamatic.ai allows you to validate your entire flow from start to finish before d
 Each test run executes the full flow using your provided input, showing node-by-node progress and output.
 </Callout>
 
+
 ## Trigger-Specific Testing Approaches
 
 Different triggers require unique testing methods:
@@ -11618,7 +11789,7 @@ Different triggers require unique testing methods:
 
 # Prompt Testing
 
-Source: https://lamatic.ai/docs/tests/prompt-testing
+Source: https://lamatic.ai/docs/tests/prompt-testing.md
 
 # Prompt Testing
 
@@ -11644,7 +11815,7 @@ Prompt testing is essential for:
 
 # Caching
 
-Source: https://lamatic.ai/docs/deployments/cache
+Source: https://lamatic.ai/docs/deployments/cache.md
 
 # Caching
 
@@ -11695,7 +11866,7 @@ Implementing caching in Lamatic.ai offers several benefits for our users:
 
 # GraphQL API
 
-Source: https://lamatic.ai/docs/interface/graphql
+Source: https://lamatic.ai/docs/interface/graphql.md
 
 # Executing Flows with GraphQL API
 
@@ -11773,6 +11944,7 @@ Here's an example GraphQL query that demonstrates how you can trigger a flow:
         "workflowId": "YOUR_WORKFLOW_ID",
         "topic": "topic"
       };
+
 
       const options = {
         method: 'POST',
@@ -12075,6 +12247,7 @@ If the request is successful, the response will follow this structure:
 ##### In-Progress Status
 If the request is still being processed, the response will be:
 
+
 ```json
   {
     "data": {
@@ -12092,7 +12265,7 @@ In this example, the `ExecuteWorkflow` query is used to initiate a workflow exec
 
 # Mailhook
 
-Source: https://lamatic.ai/docs/interface/mailhook
+Source: https://lamatic.ai/docs/interface/mailhook.md
 
 # Mailhook
 
@@ -12164,9 +12337,10 @@ Mailhooks give you a simple, event-driven way to turn incoming email into automa
 
 # Webhooks
 
-Source: https://lamatic.ai/docs/interface/webhooks
+Source: https://lamatic.ai/docs/interface/webhooks.md
 
 # Webhook Integration Guide
+
 
 Webhooks are user-defined HTTP callbacks that trigger events in external systems. They allow you to automate flow by sending real-time notifications when specific events occur.
 
@@ -12236,7 +12410,7 @@ Lamatic’s webhook capabilities allow you to build robust, event-driven flow th
 
 # Ask Widget
 
-Source: https://lamatic.ai/docs/interface/widgets/ask-widget
+Source: https://lamatic.ai/docs/interface/widgets/ask-widget.md
 
 # Ask Widget
 
@@ -12387,7 +12561,7 @@ The flow’s response is then rendered in the widget (e.g. as the AI reply and o
 
 # Chat Widget
 
-Source: https://lamatic.ai/docs/interface/widgets/chat
+Source: https://lamatic.ai/docs/interface/widgets/chat.md
 
 # Chat Widget
 
@@ -12406,6 +12580,7 @@ To use the Chat Widget, you need to whitelist the domains where you will deploy 
 - **Update your `chatTrigger` settings** to include the domains you plan to use.
 
 ### 2. Configure the Chat Widget
+
 
 Click the Configure button in the chat widget to customize settings such as the bot name, position, image, policy URL, appearance, and messages.
 
@@ -12462,6 +12637,7 @@ A live preview panel is available on the right side to visualize real-time chang
 #### Final Step
 
 After customizing, don't forget to click **Save** to apply your changes.
+
 
 ### 3. Include the CDN Script and Configure the Widget
 
@@ -12670,7 +12846,7 @@ This documentation provides a comprehensive guide to integrating the chat widget
 
 # Search Widget
 
-Source: https://lamatic.ai/docs/interface/widgets/search
+Source: https://lamatic.ai/docs/interface/widgets/search.md
 
 # Search Widget
 
@@ -12695,6 +12871,8 @@ To use the Search Widget, you need to whitelist the domains where you will deplo
 ![chatwidget.webp](./img/search-config.png)
 Click the Configure button in the search widget to customize settings such as the bot name, position, image, policy URL, appearance, and messages.
 
+
+
 ## General Configuration
 
 ### 1. Search Placeholder
@@ -12718,6 +12896,7 @@ Click the Configure button in the search widget to customize settings such as th
 - `Show Navigation Helper Text` — Enables arrow key navigation tips.
 - `Show Escape Helper Text` — Displays `esc to close` text.
 - `Show Lamatic Banner` — Shows the "Powered by Lamatic.ai" badge.
+
 
 ---
 
@@ -12744,8 +12923,10 @@ Click the Configure button in the search widget to customize settings such as th
 - **Description:** Select an Ask flow to run alongside the search widget. When configured, the Ask widget is available from the search widget’s dropdown menu, so users can use both search and Ask in the same interface.
 - **Effect:** Enables the Ask widget to run alongside the search widget from the search widget node config dropdown.
 
+
 ### Saving Your Settings
 - After configuring your widget, click **Save** (top-right) to apply changes.
+
 
 ### 2. Include the CDN Script and Configure the Widget
 
@@ -12823,15 +13004,18 @@ The output schema of the search widget would be as below:
 
 # Langfuse Integration
 
-Source: https://lamatic.ai/docs/reports/langfuse-integration
+Source: https://lamatic.ai/docs/reports/langfuse-integration.md
 
 # [Langfuse](https://langfuse.com/) Integration
 
 At Lamatic.ai, we understand the critical role that Large Language Models (LLMs) play in powering our cutting-edge GenAI applications. To ensure optimal performance, transparency, and cost-effectiveness, we've integrated Langfuse, a powerful tracing and optimization tool specifically designed for LLM interactions.
 
+
 ![Langfuse](/assets/langfuse.png)
 
 ## What is Langfuse?
+
+
 
 Langfuse is a state-of-the-art solution that provides deep insights into your LLM interactions, enabling you to monitor, analyze, and optimize the performance and cost of your GenAI applications. With Langfuse, you can unlock a new level of visibility and control over your LLM usage, empowering you to make informed decisions and continuously improve your flows.
 
@@ -12858,7 +13042,7 @@ By capturing this valuable data, Langfuse enables you to:
 
 # API Keys
 
-Source: https://lamatic.ai/docs/api-integration/api-key
+Source: https://lamatic.ai/docs/api-integration/api-key.md
 
 # API Keys
 
@@ -12910,7 +13094,7 @@ The Enterprise (org-level) API key (`lt-org-...`) is used for managing your Lama
 - Managing flows (create, update, delete)
 - Managing credentials (model keys, integrations)
 - Managing contexts and deployments
-- Listing resources across your org — and much more
+- Listing resources across your org, and much more
 
 ## When to use which
 
@@ -12926,7 +13110,7 @@ The Enterprise (org-level) API key (`lt-org-...`) is used for managing your Lama
 
 # API Overview
 
-Source: https://lamatic.ai/docs/api-integration
+Source: https://lamatic.ai/docs/api-integration.md
 
 # API Overview
 
@@ -12936,9 +13120,9 @@ Lamatic exposes a **GraphQL API** as the primary way to run Flows from your app,
 
 Most developer tools use REST (`POST /api/v1/flows/{id}/execute`). Lamatic uses **GraphQL** because:
 
-- **Dynamic schemas** — The shape of inputs and outputs depends on how your Flow is configured. GraphQL lets you request exactly the fields you need and matches the response to your Flow's schema.
-- **Single endpoint** — One URL per project; the operation and variables are in the request body.
-- **Strong typing** — Queries and responses align with your Flow's input/output definitions.
+- **Dynamic schemas**: The shape of inputs and outputs depends on how your Flow is configured. GraphQL lets you request exactly the fields you need and matches the response to your Flow's schema.
+- **Single endpoint**: One URL per project; the operation and variables are in the request body.
+- **Strong typing**: Queries and responses align with your Flow's input/output definitions.
 
 If you're used to REST, you can think of "execute a Flow" as a single mutation: `executeWorkflow(workflowId, payload)`.
 
@@ -12983,27 +13167,28 @@ The response includes `status` (e.g. `success`) and `result` (your Flow's output
 
 ## Next steps
 
-- [Integration Guide](/docs/sdk/integration-guide) — Step-by-step setup and examples in JavaScript, Python, and cURL.
-- [GraphQL](/docs/interface/graphql) — Full request/response shapes, async flows, and schema.
-- [Error Codes](/docs/error-reference) — Diagnose failed requests.
-- [Limits & Quotas](/docs/limits) — Rate limits and payload size.
+- [Integration Guide](/docs/sdk/integration-guide): Step-by-step setup and examples in JavaScript, Python, and cURL.
+- [GraphQL](/docs/interface/graphql): Full request/response shapes, async flows, and schema.
+- [Error Codes](/docs/error-reference): Diagnose failed requests.
+- [Limits & Quotas](/docs/limits): Rate limits and payload size.
 
 
 ---
 
 # Lamatic Docs MCP
 
-Source: https://lamatic.ai/docs/mcp/docs-mcp
+Source: https://lamatic.ai/docs/mcp/docs-mcp.md
 
 # Lamatic Docs MCP
 
-> Query Lamatic.ai documentation instantly from any AI assistant — no searching, no tab switching, just answers.
+> Query Lamatic.ai documentation instantly from any AI assistant. No searching, no tab switching, just answers.
 
 ---
 
 ## What is the Docs MCP?
 
 The **Lamatic Docs MCP** is a [Model Context Protocol](https://modelcontextprotocol.io) server that gives AI assistants like Claude, Cursor, and Windsurf direct access to Lamatic.ai documentation.
+
 
 It is powered by a RAG pipeline built entirely on Lamatic:
 - **Firecrawl** scrapes the docs
@@ -13052,6 +13237,7 @@ Restart Claude Desktop after saving. You should see a 🔌 tools icon in the cha
 
 Add the same config to your MCP settings. Most clients support the `url` field directly for HTTP-based MCP servers.
 
+
 ## Available Tools
 
 ### `query_docs`
@@ -13095,9 +13281,9 @@ Answer
 
 The entire pipeline is built on Lamatic:
 
-1. **Indexing Flow** — scrapes `lamatic.ai/docs` using Firecrawl, chunks content, vectorizes and stores in VectorDB
-2. **Query Flow** — takes your question, runs semantic search, generates answer
-3. **MCP Server** — Next.js API route deployed on Vercel, calls the query flow via GraphQL
+1. **Indexing Flow**: scrapes `lamatic.ai/docs` using Firecrawl, chunks content, vectorizes and stores in VectorDB
+2. **Query Flow**: takes your question, runs semantic search, generates answer
+3. **MCP Server**: Next.js API route deployed on Vercel, calls the query flow via GraphQL
 
 ---
 
@@ -13121,7 +13307,7 @@ The MCP is open source. You can view, fork, and contribute on GitHub:
 
 {/*
 <Callout type="tip">
-  Want to build your own Docs MCP for your company? See the [Docs MCP setup guide](/docs/mcp-tools/docs-mcp) — fork the repo, connect your own Lamatic flow, and deploy to Vercel in minutes.
+  Want to build your own Docs MCP for your company? See the [Docs MCP setup guide](/docs/mcp-tools/docs-mcp). Fork the repo, connect your own Lamatic flow, and deploy to Vercel in minutes.
 </Callout>
 */}
 
@@ -13140,7 +13326,7 @@ Found an issue or want to suggest an improvement?
 
 # Graph MCP
 
-Source: https://lamatic.ai/docs/mcp/graph-mcp
+Source: https://lamatic.ai/docs/mcp/graph-mcp.md
 
 # Graph MCP (Beta)
 
@@ -13150,7 +13336,7 @@ Source: https://lamatic.ai/docs/mcp/graph-mcp
 
 ## What is it?
 
-**Lamatic Graph MCP** is an [Model Context Protocol](https://modelcontextprotocol.io) server that turns your deployed Lamatic flows into AI-callable tools. Connect Claude, GitHub Copilot, or Cursor — your flows become tools your AI can call directly using natural language.
+**Lamatic Graph MCP** is an [Model Context Protocol](https://modelcontextprotocol.io) server that turns your deployed Lamatic flows into AI-callable tools. Connect Claude, GitHub Copilot, or Cursor, and your flows become tools your AI can call directly using natural language.
 
 ---
 
@@ -13283,20 +13469,26 @@ refresh my flows
 
 - [GitHub repository](https://github.com/Lamatic/GraphMCP-Lamatic)
 - [npm package](https://www.npmjs.com/package/@lamatic/graph-mcp)
-- [Dev MCP](/docs/dev-mcp) — Manage Lamatic projects via AI
+- [Dev MCP](/docs/dev-mcp): Manage Lamatic projects via AI
 
 
 ---
 
 # MCP Overview
 
-Source: https://lamatic.ai/docs/mcp
+Source: https://lamatic.ai/docs/mcp.md
 
 # MCP in Lamatic
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard for connecting AI assistants to external systems — data sources, APIs, tools, and services — through a single uniform interface.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open standard for connecting AI assistants to external systems — data sources, APIs, tools, and services — through one uniform interface.
 
-Lamatic ships **three MCP-related products**, each solving a different direction of the protocol.
+Lamatic ships three MCP products, each covering a different direction of the protocol:
+
+- **[MCP Node](/docs/mcp/mcp-node)** lets your flow consume tools from any external MCP server.
+- **[Graph MCP](/docs/mcp/graph-mcp)** exposes your deployed flows as MCP tools that external AI assistants can call.
+- **[Docs MCP](/docs/mcp/docs-mcp)** is a hosted MCP server that answers questions about Lamatic itself.
+
+{/* TODO: replace with mcp/img/mcp-overview.png — see Image Needs section in the conversation that produced this file */}
 
 ---
 
@@ -13304,57 +13496,57 @@ Lamatic ships **three MCP-related products**, each solving a different direction
 
 ### MCP Node — consume external MCP servers
 
-The [MCP Node](/docs/mcp/mcp-node) lets a Lamatic flow connect to an existing MCP server and use its tools and data from inside your flow. You configure the server URL, headers, and protocol once; the node makes those tools available to any AI node downstream.
+The [MCP Node](/docs/mcp/mcp-node) connects your Lamatic flow to an existing MCP server. Configure the server's URL, headers, and protocol once, and any AI node downstream can call the tools that server exposes.
 
-**Use it when:** you want your flow to talk to a third-party MCP server (e.g. a weather API, a database, an internal tool catalog) and have the AI nodes inside the flow call those tools.
+**Use it when** you want your flow to call a third-party MCP server, such as a weather API, a database, or an internal tool catalog.
 
 ### Graph MCP — expose your flows as MCP tools
 
-[Graph MCP](/docs/mcp/graph-mcp) is the inverse. It turns your deployed Lamatic flows into MCP-callable tools so any MCP client (Claude Desktop, Cursor, VS Code, etc.) can invoke them with natural language.
+[Graph MCP](/docs/mcp/graph-mcp) runs in the opposite direction: it turns your deployed Lamatic flows into MCP-callable tools. Any MCP client (Claude Desktop, Cursor, VS Code, custom agents) can then invoke those flows with natural language.
 
-**Use it when:** you want an external AI assistant to drive your Lamatic flows — for example, a developer using Cursor to trigger a flow that generates a report.
+**Use it when** you want an external AI assistant to drive your flows. For example, a developer in Cursor triggering a flow that generates a weekly report.
 
 ### Docs MCP — query Lamatic docs from any AI assistant
 
-[Docs MCP](/docs/mcp/docs-mcp) is a hosted MCP server maintained by Lamatic. It indexes [lamatic.ai/docs](https://lamatic.ai/docs) into a RAG pipeline and exposes a `query_docs` tool so any MCP client can ask natural-language questions about Lamatic and get answers with references — no setup, no API key.
+[Docs MCP](/docs/mcp/docs-mcp) is a hosted MCP server that Lamatic maintains. It indexes [lamatic.ai/docs](https://lamatic.ai/docs) into a RAG pipeline and exposes a `query_docs` tool. Any MCP client can ask natural-language questions about Lamatic and get answers with references. No setup, no API key.
 
-**Use it when:** you want your AI assistant to answer questions about Lamatic itself — its nodes, agents, integrations, error messages — instead of searching the docs manually.
+**Use it when** you want your AI assistant to answer questions about Lamatic itself — its nodes, agents, integrations, error messages — instead of you searching the docs manually.
 
 ---
 
 ## When to use which
 
-|                      | MCP Node                                       | Graph MCP                                      | Docs MCP                                                     |
-| -------------------- | ---------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
-| **Direction**        | Lamatic flow → external MCP server             | External MCP client → Lamatic flow             | External MCP client → Lamatic's hosted docs server           |
-| **Role**             | Client / consumer                              | Server / provider                              | Server / provider (hosted by Lamatic)                        |
-| **What you provide** | The URL of an external MCP server              | A deployed flow with an API trigger            | Nothing — it's hosted                                        |
-| **What you get**     | External tools available inside the flow       | Your flow callable from any MCP client         | A `query_docs` tool that answers questions about Lamatic     |
-| **Typical caller**   | AI nodes in your flow                          | Claude Desktop, Cursor, VS Code, custom agents | Claude Desktop, Cursor, anyone reading the docs              |
-| **Auth model**       | Headers / API keys you configure on the node   | Org API key + Project API key                  | None — free to use                                           |
-| **Setup location**   | Studio → MCP/Tools → MCP                       | `npx @lamatic/graph-mcp` in the client's config | Add `https://docmcp.lamatic.ai/api/mcp` to your client config |
+|                      | MCP Node                                        | Graph MCP                                       | Docs MCP                                                      |
+| -------------------- | ----------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------- |
+| **Direction**        | Lamatic flow → external MCP server              | External MCP client → Lamatic flow              | External MCP client → Lamatic-hosted docs server              |
+| **Role**             | Client (consumer)                               | Server (provider)                               | Server (hosted by Lamatic)                                    |
+| **What you provide** | The URL of an external MCP server               | A deployed flow with an API trigger             | Nothing — it's hosted                                         |
+| **What you get**     | External tools available inside the flow        | Your flow callable from any MCP client          | A `query_docs` tool that answers questions about Lamatic      |
+| **Typical caller**   | AI nodes inside your flow                       | Claude Desktop, Cursor, VS Code, custom agents  | Claude Desktop, Cursor, anyone reading the docs               |
+| **Auth model**       | Headers and API keys you set on the node        | Org API key + Project API key                   | None (free to use)                                            |
+| **Setup location**   | Studio → MCP/Tools → MCP                        | `npx @lamatic/graph-mcp` in the client's config | Add `https://docmcp.lamatic.ai/api/mcp` to your client config |
 
 ---
 
 ## Quick chooser
 
-- *"I want my flow to use tools from an external service via MCP."* → [MCP Node](/docs/mcp/mcp-node)
-- *"I want Claude/Cursor to call my Lamatic flow."* → [Graph MCP](/docs/mcp/graph-mcp)
-- *"I want my AI assistant to answer questions about Lamatic itself."* → [Docs MCP](/docs/mcp/docs-mcp)
-- *Combine them.* → A flow that consumes external MCP tools (MCP Node) can itself be exposed via Graph MCP, while you use Docs MCP to ask your assistant about Lamatic as you build.
+- "I want my flow to use tools from an external service via MCP." → [MCP Node](/docs/mcp/mcp-node)
+- "I want Claude or Cursor to call my Lamatic flow." → [Graph MCP](/docs/mcp/graph-mcp)
+- "I want my AI assistant to answer questions about Lamatic itself." → [Docs MCP](/docs/mcp/docs-mcp)
+- All of the above. → A flow that consumes external MCP tools (MCP Node) can itself be exposed via Graph MCP, while you use Docs MCP to ask your assistant about Lamatic as you build.
 
 ---
 
 ## Related
 
-- [Generate Text Node](/docs/nodes/ai/generate-text-node) — can integrate MCP tools loaded by the MCP Node
+- [Generate Text Node](/docs/nodes/ai/generate-text-node) — integrates MCP tools loaded by the MCP Node.
 
 
 ---
 
 # MCP Node
 
-Source: https://lamatic.ai/docs/mcp/mcp-node
+Source: https://lamatic.ai/docs/mcp/mcp-node.md
 
 # MCP Node
 
@@ -13506,7 +13698,7 @@ The MCP node allows you to:
 
 # Go
 
-Source: https://lamatic.ai/docs/sdk/go
+Source: https://lamatic.ai/docs/sdk/go.md
 
 # Using Lamatic SDK with Go
 
@@ -13648,6 +13840,7 @@ func main() {
     }
 }
 ```
+
 
 ## Checking Request Status
 
@@ -13891,7 +14084,7 @@ For help and support with the Go SDK:
 
 # SDK & Integration Guide
 
-Source: https://lamatic.ai/docs/sdk
+Source: https://lamatic.ai/docs/sdk.md
 
 # Lamatic SDK
 
@@ -13939,6 +14132,7 @@ const lamatic = new Lamatic({
 ## Authentication
 
 The SDK supports two authentication methods:
+
 
 <Tabs items={['API Key', 'Access Token']}>
   <Tabs.Tab>
@@ -14032,6 +14226,7 @@ main();
 </Tabs>
 
 ### Handling Expired Access Tokens
+
 
 <Callout type="info">
   This example shows how to handle an expired access token by fetching a new one
@@ -14590,7 +14785,7 @@ For help and support, visit our [documentation](https://docs.lamatic.ai) or cont
 
 # Integration Guide
 
-Source: https://lamatic.ai/docs/sdk/integration-guide
+Source: https://lamatic.ai/docs/sdk/integration-guide.md
 
 # Integration Guide
 
@@ -14893,7 +15088,7 @@ The response structure can be configured in the **Schema** of the GraphQL Respon
 
 # Next.js
 
-Source: https://lamatic.ai/docs/sdk/next
+Source: https://lamatic.ai/docs/sdk/next.md
 
 # Using Lamatic SDK with Next.js
 
@@ -14966,7 +15161,7 @@ When the button is clicked, the component will execute the flow and log the resp
 
 # React SDK
 
-Source: https://lamatic.ai/docs/sdk/react
+Source: https://lamatic.ai/docs/sdk/react.md
 
 # Using Lamatic SDK with React
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,164 +6,164 @@
 
 ## Getting Started
 
-- [Agents](https://lamatic.ai/docs/agents): Agents in Lamatic.ai Studio
-- [Architecture](https://lamatic.ai/docs/architecture): How does Lamatic work?
-- [CLI](https://lamatic.ai/docs/cli): The official Lamatic CLI for managing projects, flows, deployments, contexts, models, and integrations from the terminal.
-- [Context](https://lamatic.ai/docs/context): Context in Lamatic Studio
-- [Contributing](https://lamatic.ai/docs/contributing): Contributing to Lamatic.ai Documentation
-- [Edge Deployment](https://lamatic.ai/docs/deployments): Edge Deployment in Lamatic.ai
-- [Environments](https://lamatic.ai/docs/environment): Create and manage different environments for your flows using branching and merging in Lamatic AI.
-- [Error Codes](https://lamatic.ai/docs/error-reference): Reference for error codes, HTTP status codes, and how to fix common API and Flow failures.
-- [Feedback API](https://lamatic.ai/docs/feedback-api): Collect feedback from any flows, specifically GraphQL APIs, to improve your AI applications.
-- [Flow Integration](https://lamatic.ai/docs/flow-integration): Integrate a developed flow into your application — Connect to your project, API, Vibe Code Prompt, and app frameworks.
-- [Flows](https://lamatic.ai/docs/flows): Flow builder in Lamatic.ai Studio
-- [Quickstart Guide](https://lamatic.ai/docs/get-started): Quickly get your first project off the ground with Lamatic.
-- [Glossary](https://lamatic.ai/docs/glossary): Common terms and concepts in Lamatic.ai explained in simple language
-- [IDE](https://lamatic.ai/docs/ide): IDE Inside lamatic.ai studio
-- [Overview](https://lamatic.ai/docs): Lamatic is a collaborative GenOps platform. It helps cross-functional product teams build and deploy GenAI faster and better.
-- [Interfaces](https://lamatic.ai/docs/interface): Connect to Lamatic platform using Interfaces
-- [IP Allowlisting](https://lamatic.ai/docs/ips): IP addresses and network guidance to allowlist Lamatic in customer firewalls for databases, apps, webhooks, API calls, and external systems.
-- [Jobs](https://lamatic.ai/docs/jobs): Lamatic Studio
-- [Logs](https://lamatic.ai/docs/logs): Logs in Lamatic.ai
-- [Models](https://lamatic.ai/docs/models): Models in Lamatic Studio
-- [Nodes](https://lamatic.ai/docs/nodes): Nodes are the fundamental building blocks of a flow in Lamatic. Each node serves a specific purpose, acting as a self-contained unit that processes input and produces output.
-- [Reports](https://lamatic.ai/docs/reports): Reporting in Lamatic Studio
-- [Templates](https://lamatic.ai/docs/templates): Templates in Lamatic.ai Studio
-- [Version Control](https://lamatic.ai/docs/version-control): Manage, preview, and duplicate previous versions of your flow in Lamatic AI.
-- [Vibe Build Overview](https://lamatic.ai/docs/vibe-build): Use the Vibe Build home to launch agents, pick templates, and connect data sources in Lamatic AI.
+- [Agents](https://lamatic.ai/docs/agents.md): Agents in Lamatic.ai Studio
+- [Architecture](https://lamatic.ai/docs/architecture.md): How does Lamatic work?
+- [Lamatic CLI (Beta)](https://lamatic.ai/docs/cli.md): The official Lamatic CLI for managing projects, flows, deployments, contexts, models, and integrations from the terminal.
+- [Context](https://lamatic.ai/docs/context.md): Context in Lamatic Studio
+- [Contributing](https://lamatic.ai/docs/contributing.md): Contributing to Lamatic.ai Documentation
+- [Edge Deployment](https://lamatic.ai/docs/deployments.md): Edge Deployment in Lamatic.ai
+- [Environments](https://lamatic.ai/docs/environment.md): Create and manage different environments for your flows using branching and merging in Lamatic AI.
+- [Error Codes](https://lamatic.ai/docs/error-reference.md): Reference for error codes, HTTP status codes, and how to fix common API and Flow failures.
+- [Feedback API](https://lamatic.ai/docs/feedback-api.md): Collect feedback from any flows, specifically GraphQL APIs, to improve your AI applications.
+- [Flow Integration](https://lamatic.ai/docs/flow-integration.md): Integrate a developed flow into your application — Connect to your project, API, Vibe Code Prompt, and app frameworks.
+- [Flows](https://lamatic.ai/docs/flows.md): Flow builder in Lamatic.ai Studio
+- [Quickstart Guide](https://lamatic.ai/docs/get-started.md): Quickly get your first project off the ground with Lamatic.
+- [Glossary](https://lamatic.ai/docs/glossary.md): Common terms and concepts in Lamatic.ai explained in simple language
+- [IDE](https://lamatic.ai/docs/ide.md): IDE Inside lamatic.ai studio
+- [Overview](https://lamatic.ai/docs.md): Lamatic is a collaborative GenOps platform. It helps cross-functional product teams build and deploy GenAI faster and better.
+- [Interfaces](https://lamatic.ai/docs/interface.md): Connect to Lamatic platform using Interfaces
+- [IP Allowlisting](https://lamatic.ai/docs/ips.md): IP addresses and network guidance to allowlist Lamatic in customer firewalls for databases, apps, webhooks, API calls, and external systems.
+- [Jobs](https://lamatic.ai/docs/jobs.md): Lamatic Studio
+- [Logs](https://lamatic.ai/docs/logs.md): Logs in Lamatic.ai
+- [Models](https://lamatic.ai/docs/models.md): Models in Lamatic Studio
+- [Nodes](https://lamatic.ai/docs/nodes.md): Nodes are the fundamental building blocks of a flow in Lamatic. Each node serves a specific purpose, acting as a self-contained unit that processes input and produces output.
+- [Reports](https://lamatic.ai/docs/reports.md): Reporting in Lamatic Studio
+- [Templates](https://lamatic.ai/docs/templates.md): Templates in Lamatic.ai Studio
+- [Version Control](https://lamatic.ai/docs/version-control.md): Manage, preview, and duplicate previous versions of your flow in Lamatic AI.
+- [Vibe Build Overview](https://lamatic.ai/docs/vibe-build.md): Use the Vibe Build home to launch agents, pick templates, and connect data sources in Lamatic AI.
 
 ## Concepts
 
-- [AI Middleware](https://lamatic.ai/docs/concepts/ai-middleware): Lamatic AI as a GenAI middleware solution - easy to implement and deploy
-- [LLM Prompting Techniques](https://lamatic.ai/docs/concepts/llm-prompting): Learn effective prompting techniques to get the most out of Large Language Models with practical examples and best practices.
-- [What is Retrieval-Augmented Generation (RAG)?](https://lamatic.ai/docs/concepts/rag): Retrieval-Augmented Generation (RAG) is an AI framework that enhances the performance of Large Language Models (LLMs) by integrating external information retrieval mechanisms.
-- [Vibe Coding with Lamatic.ai](https://lamatic.ai/docs/concepts/vibe-coding-setup): How to integrate LLM-powered vibe coding tools like GitHub Copilot and Cursor within Lamatic.ai Docs for context-aware, intelligent development.
+- [AI Middleware](https://lamatic.ai/docs/concepts/ai-middleware.md): Lamatic AI as a GenAI middleware solution - easy to implement and deploy
+- [LLM Prompting Techniques](https://lamatic.ai/docs/concepts/llm-prompting.md): Learn effective prompting techniques to get the most out of Large Language Models with practical examples and best practices.
+- [What is Retrieval-Augmented Generation (RAG)?](https://lamatic.ai/docs/concepts/rag.md): Retrieval-Augmented Generation (RAG) is an AI framework that enhances the performance of Large Language Models (LLMs) by integrating external information retrieval mechanisms.
+- [Vibe Coding with Lamatic.ai](https://lamatic.ai/docs/concepts/vibe-coding-setup.md): How to integrate LLM-powered vibe coding tools like GitHub Copilot and Cursor within Lamatic.ai Docs for context-aware, intelligent development.
 
 ## Studio
 
-- [Authentication with API Keys](https://lamatic.ai/docs/studio/studio-keys): To ensure secure access to our platform, Lamatic.ai employs API keys for authentication.
-- [Studio Overview](https://lamatic.ai/docs/studio/studio-overview): Lamatic Studio -  Command and Control for Lamatic Projects
-- [Projects](https://lamatic.ai/docs/studio/studio-project): Projects in Lamatic Studio
-- [Role-Based Access](https://lamatic.ai/docs/studio/studio-role-based-access): Learn what each Lamatic.ai role can do, with organization and project permission tables for owners, admins, editors, developers, and viewers.
-- [Tags](https://lamatic.ai/docs/studio/studio-tags): Organize and filter flows using tags for better accessibility and management
-- [Variables & Secrets](https://lamatic.ai/docs/studio/studio-variables-and-secrets): Store and manage variables, API keys, and secrets securely in Lamatic and reference them across flows without exposing values.
+- [Authentication with API Keys](https://lamatic.ai/docs/studio/studio-keys.md): To ensure secure access to our platform, Lamatic.ai employs API keys for authentication.
+- [Studio Overview](https://lamatic.ai/docs/studio/studio-overview.md): Lamatic Studio -  Command and Control for Lamatic Projects
+- [Projects](https://lamatic.ai/docs/studio/studio-project.md): Projects in Lamatic Studio
+- [Role-Based Access](https://lamatic.ai/docs/studio/studio-role-based-access.md): Learn what each Lamatic.ai role can do, with organization and project permission tables for owners, admins, editors, developers, and viewers.
+- [Tags](https://lamatic.ai/docs/studio/studio-tags.md): Organize and filter flows using tags for better accessibility and management
+- [Variables & Secrets](https://lamatic.ai/docs/studio/studio-variables-and-secrets.md): Store and manage variables, API keys, and secrets securely in Lamatic and reference them across flows without exposing values.
 
 ## Flows
 
-- [Flow Editor](https://lamatic.ai/docs/flows/editor): Flow Editor in Lamatic Studio
-- [Flow AI Assistant](https://lamatic.ai/docs/flows/flow-assistant): Flow AI Assistant in Lamatic Studio
-- [Flow Config](https://lamatic.ai/docs/flows/flow-config): Flow Config
-- [Node Configuration](https://lamatic.ai/docs/flows/node-config): Node Configuration for node
-- [Nodes](https://lamatic.ai/docs/flows/nodes): Learn about nodes in Lamatic flows - the fundamental building blocks that process and transform data in your workflows.
-- [Sticky notes](https://lamatic.ai/docs/flows/sticky-notes): Sticky notes for enhanced workflow organization in Lamatic AI.
-- [Variables](https://lamatic.ai/docs/flows/variables): Variables in Lamatic Studio
+- [Flow Editor](https://lamatic.ai/docs/flows/editor.md): Flow Editor in Lamatic Studio
+- [Flow AI Assistant](https://lamatic.ai/docs/flows/flow-assistant.md): Flow AI Assistant in Lamatic Studio
+- [Flow Config](https://lamatic.ai/docs/flows/flow-config.md): Flow Config
+- [Node Configuration](https://lamatic.ai/docs/flows/node-config.md): Node Configuration for node
+- [Nodes](https://lamatic.ai/docs/flows/nodes.md): Learn about nodes in Lamatic flows - the fundamental building blocks that process and transform data in your workflows.
+- [Sticky notes](https://lamatic.ai/docs/flows/sticky-notes.md): Sticky notes for enhanced workflow organization in Lamatic AI.
+- [Variables](https://lamatic.ai/docs/flows/variables.md): Variables in Lamatic Studio
 
 ## Nodes
 
-- [Classifier Node](https://lamatic.ai/docs/nodes/ai/classifier-node): The Classifier Node allows users to categorize and classify data based on predefined criteria or machine learning models.
-- [Doc Extractor Node](https://lamatic.ai/docs/nodes/ai/doc-extractor): The Doc Extractor node uses an LLM to extract structured information from document URLs and return results in markdown, JSON, or plain text.
-- [Generate Image Node](https://lamatic.ai/docs/nodes/ai/generate-image-node): The Generate Image Node allows users to create images using AI models based on text prompts and configuration parameters.
-- [Generate JSON Node](https://lamatic.ai/docs/nodes/ai/generate-json-node): The Generate JSON Node allows users to generate structured JSON data using AI models with predefined schemas.
-- [Generate Text Node](https://lamatic.ai/docs/nodes/ai/generate-text-node): The Generate Text node allows users to programmatically generate text outputs by submitting prompts to selected LLMs.
-- [MCP Node](https://lamatic.ai/docs/nodes/ai/mcp-node): The MCP Node allows users to connect to and interact with external data sources and tools through the Model Context Protocol (MCP).
-- [Multimodal Node](https://lamatic.ai/docs/nodes/ai/multimodal-node): The Multimodal Node allows users to process multiple types of data (text, images, audio) using AI models in a single workflow.
-- [RAG Node](https://lamatic.ai/docs/nodes/ai/rag-node): The RAG (Retrieval-Augmented Generation) Node combines information retrieval with text generation to provide contextually relevant responses.
-- [Supervisor Node](https://lamatic.ai/docs/nodes/ai/supervisor-node): The Supervisor Node monitors and manages the execution of other nodes in a workflow, providing oversight and control capabilities.
-- [API Node](https://lamatic.ai/docs/nodes/data/api-node): The Lamatic.ai API Node empowers users to external REST APIs seamlessly into their flow.
-- [Chunking Node](https://lamatic.ai/docs/nodes/data/chunking-node): The Chunking Node breaks down large text documents into smaller, manageable chunks for processing by AI models.
-- [Extract from File Node](https://lamatic.ai/docs/nodes/data/extract-from-file-node): The Extract from File Node extracts and processes data from various file formats including PDFs, Word documents, and text files.
-- [Hybrid Search Node](https://lamatic.ai/docs/nodes/data/hybrid-search-node): The Hybrid Search Node combines multiple search strategies to provide comprehensive and accurate search results from vector databases.
-- [Keyword Search Node](https://lamatic.ai/docs/nodes/data/keyword-search-node): The Keyword Search Node performs text-based searches using specific keywords and phrases to find relevant content.
-- [Memory Add Node](https://lamatic.ai/docs/nodes/data/memory-add-node): The Memory Add Node stores and manages data in memory for use across workflow executions.
-- [Memory Retrieve Node](https://lamatic.ai/docs/nodes/data/memory-retrieve-node): The Memory Retrieve Node retrieves stored data from memory for use in current workflow executions.
-- [Tables Node](https://lamatic.ai/docs/nodes/data/tables-node): The Tables Node performs various operations on structured data tables including querying, inserting, updating, and deleting records.
-- [Keyword Search Node](https://lamatic.ai/docs/nodes/data/vector-search-node): The Keyword Search Node performs text-based searches using specific keywords and phrases to find relevant content.
-- [VectorDB Node](https://lamatic.ai/docs/nodes/data/vectordb-node): The VectorDB Node performs various operations on vector databases including insertion, deletion, and management of vector data.
-- [Vectorize Node](https://lamatic.ai/docs/nodes/data/vectorize-node): The Vectorize Node converts text data into vector embeddings for use in semantic search and AI applications.
-- [Batch Node](https://lamatic.ai/docs/nodes/logic/batch-node): The Batch Node iterates over a list or a range and runs each iteration in parallel with a configurable concurrency limit.
-- [Branch Node](https://lamatic.ai/docs/nodes/logic/branch-node): The Branch Node creates multiple execution paths in a workflow based on conditions or data routing logic.
-- [Code Node](https://lamatic.ai/docs/nodes/logic/code-node): The Code Node allows users to execute custom JavaScript code within workflows for data processing and logic implementation.
-- [Condition Node](https://lamatic.ai/docs/nodes/logic/condition-node): The Lamatic.ai Condition Node allows users to integrate custom logic into their flow with ease.
-- [End Node](https://lamatic.ai/docs/nodes/logic/end-node): The End Node stops flow execution immediately and returns control to the Final Trigger Response node.
-- [Execute Flow Node](https://lamatic.ai/docs/nodes/logic/execute-flow): The Execute Flow Node allows users to call and execute other workflows from within a current workflow.
-- [Loop Node](https://lamatic.ai/docs/nodes/logic/loop-node): The Loop Node enables iterative processing of data by repeating operations on collections or arrays of data.
-- [Variable Node](https://lamatic.ai/docs/nodes/logic/variable-node): The Variable Node allows users to define and manage variables for storing and manipulating data within workflows.
-- [Wait Node](https://lamatic.ai/docs/nodes/logic/wait-node): The Wait Node introduces delays in workflow execution for timing control and rate limiting purposes.
-- [Node Assistant](https://lamatic.ai/docs/nodes/node-assistant): Node AI Assistant in Lamatic Studio - Get AI-powered assistance for configuring individual nodes
-- [Node Logic](https://lamatic.ai/docs/nodes/node-logic): Node Logic allows you to wrap and extend your node's behavior with advanced control mechanisms like conditional routing, iterative refinement, and dynamic flow control.
+- [Classifier Node](https://lamatic.ai/docs/nodes/ai/classifier-node.md): The Classifier Node allows users to categorize and classify data based on predefined criteria or machine learning models.
+- [Doc Extractor Node](https://lamatic.ai/docs/nodes/ai/doc-extractor.md): The Doc Extractor node uses an LLM to extract structured information from document URLs and return results in markdown, JSON, or plain text.
+- [Generate Image Node](https://lamatic.ai/docs/nodes/ai/generate-image-node.md): The Generate Image Node allows users to create images using AI models based on text prompts and configuration parameters.
+- [Generate JSON Node](https://lamatic.ai/docs/nodes/ai/generate-json-node.md): The Generate JSON Node allows users to generate structured JSON data using AI models with predefined schemas.
+- [Generate Text Node](https://lamatic.ai/docs/nodes/ai/generate-text-node.md): The Generate Text node allows users to programmatically generate text outputs by submitting prompts to selected LLMs.
+- [MCP Node](https://lamatic.ai/docs/nodes/ai/mcp-node.md): The MCP Node allows users to connect to and interact with external data sources and tools through the Model Context Protocol (MCP).
+- [Multimodal Node](https://lamatic.ai/docs/nodes/ai/multimodal-node.md): The Multimodal Node allows users to process multiple types of data (text, images, audio) using AI models in a single workflow.
+- [RAG Node](https://lamatic.ai/docs/nodes/ai/rag-node.md): The RAG (Retrieval-Augmented Generation) Node combines information retrieval with text generation to provide contextually relevant responses.
+- [Supervisor Node](https://lamatic.ai/docs/nodes/ai/supervisor-node.md): The Supervisor Node monitors and manages the execution of other nodes in a workflow, providing oversight and control capabilities.
+- [API Node](https://lamatic.ai/docs/nodes/data/api-node.md): The Lamatic.ai API Node empowers users to external REST APIs seamlessly into their flow.
+- [Chunking Node](https://lamatic.ai/docs/nodes/data/chunking-node.md): The Chunking Node breaks down large text documents into smaller, manageable chunks for processing by AI models.
+- [Extract from File Node](https://lamatic.ai/docs/nodes/data/extract-from-file-node.md): The Extract from File Node extracts and processes data from various file formats including PDFs, Word documents, and text files.
+- [Hybrid Search Node](https://lamatic.ai/docs/nodes/data/hybrid-search-node.md): The Hybrid Search Node combines multiple search strategies to provide comprehensive and accurate search results from vector databases.
+- [Keyword Search Node](https://lamatic.ai/docs/nodes/data/keyword-search-node.md): The Keyword Search Node performs text-based searches using specific keywords and phrases to find relevant content.
+- [Memory Add Node](https://lamatic.ai/docs/nodes/data/memory-add-node.md): The Memory Add Node stores and manages data in memory for use across workflow executions.
+- [Memory Retrieve Node](https://lamatic.ai/docs/nodes/data/memory-retrieve-node.md): The Memory Retrieve Node retrieves stored data from memory for use in current workflow executions.
+- [Tables Node](https://lamatic.ai/docs/nodes/data/tables-node.md): The Tables Node performs various operations on structured data tables including querying, inserting, updating, and deleting records.
+- [Keyword Search Node](https://lamatic.ai/docs/nodes/data/vector-search-node.md): The Keyword Search Node performs text-based searches using specific keywords and phrases to find relevant content.
+- [VectorDB Node](https://lamatic.ai/docs/nodes/data/vectordb-node.md): The VectorDB Node performs various operations on vector databases including insertion, deletion, and management of vector data.
+- [Vectorize Node](https://lamatic.ai/docs/nodes/data/vectorize-node.md): The Vectorize Node converts text data into vector embeddings for use in semantic search and AI applications.
+- [Batch Node](https://lamatic.ai/docs/nodes/logic/batch-node.md): The Batch Node iterates over a list or a range and runs each iteration in parallel with a configurable concurrency limit.
+- [Branch Node](https://lamatic.ai/docs/nodes/logic/branch-node.md): The Branch Node creates multiple execution paths in a workflow based on conditions or data routing logic.
+- [Code Node](https://lamatic.ai/docs/nodes/logic/code-node.md): The Code Node allows users to execute custom JavaScript code within workflows for data processing and logic implementation.
+- [Condition Node](https://lamatic.ai/docs/nodes/logic/condition-node.md): The Lamatic.ai Condition Node allows users to integrate custom logic into their flow with ease.
+- [End Node](https://lamatic.ai/docs/nodes/logic/end-node.md): The End Node stops flow execution immediately and returns control to the Final Trigger Response node.
+- [Execute Flow Node](https://lamatic.ai/docs/nodes/logic/execute-flow.md): The Execute Flow Node allows users to call and execute other workflows from within a current workflow.
+- [Loop Node](https://lamatic.ai/docs/nodes/logic/loop-node.md): The Loop Node enables iterative processing of data by repeating operations on collections or arrays of data.
+- [Variable Node](https://lamatic.ai/docs/nodes/logic/variable-node.md): The Variable Node allows users to define and manage variables for storing and manipulating data within workflows.
+- [Wait Node](https://lamatic.ai/docs/nodes/logic/wait-node.md): The Wait Node introduces delays in workflow execution for timing control and rate limiting purposes.
+- [Node Assistant](https://lamatic.ai/docs/nodes/node-assistant.md): Node AI Assistant in Lamatic Studio - Get AI-powered assistance for configuring individual nodes
+- [Node Logic](https://lamatic.ai/docs/nodes/node-logic.md): Node Logic allows you to wrap and extend your node's behavior with advanced control mechanisms like conditional routing, iterative refinement, and dynamic flow control.
 
 ## Agents
 
-- [Getting Started with Agents](https://lamatic.ai/docs/agents/getting-started): Getting Started with Agents in Lamatic.ai
-- [JSON Agent](https://lamatic.ai/docs/agents/json-agent): Get structured JSON from an LLM with a schema. Use it when you need a fixed output shape for APIs, pipelines, or reports.
-- [Multi Modal Agent](https://lamatic.ai/docs/agents/multi-modal-agent): The Multi Modal Agent in Lamatic.ai generates images and text content programmatically using AI models like GPT-4-Turbo.
-- [Supervisor Agent](https://lamatic.ai/docs/agents/supervisor-agent): The Supervisor Agent in Lamatic.ai orchestrates multi-agent flow by collecting input, maintaining memory, and coordinating execution paths.
-- [Text Agent](https://lamatic.ai/docs/agents/text-agent): The Text Agent in Lamatic.ai generates dynamic text outputs using customizable prompts and LLM models.
+- [Getting Started with Agents](https://lamatic.ai/docs/agents/getting-started.md): Getting Started with Agents in Lamatic.ai
+- [JSON Agent](https://lamatic.ai/docs/agents/json-agent.md): Get structured JSON from an LLM with a schema. Use it when you need a fixed output shape for APIs, pipelines, or reports.
+- [Multi Modal Agent](https://lamatic.ai/docs/agents/multi-modal-agent.md): The Multi Modal Agent in Lamatic.ai generates images and text content programmatically using AI models like GPT-4-Turbo.
+- [Supervisor Agent](https://lamatic.ai/docs/agents/supervisor-agent.md): The Supervisor Agent in Lamatic.ai orchestrates multi-agent flow by collecting input, maintaining memory, and coordinating execution paths.
+- [Text Agent](https://lamatic.ai/docs/agents/text-agent.md): The Text Agent in Lamatic.ai generates dynamic text outputs using customizable prompts and LLM models.
 
 ## Models
 
-- [Benchmarks](https://lamatic.ai/docs/models/benchmark): Compare and evaluate LLM performance using recommended benchmarks to choose the right model for your Lamatic.ai use case.
-- [Custom Model Integration](https://lamatic.ai/docs/models/custom-model-integration): With Lamatic, you can define custom models per provider — this doc walks through how to add, override, and control model behavior across different AI backends.
-- [Model Config](https://lamatic.ai/docs/models/model-config): Model Config play a crucial role in fine-tuning the behavior of Large Language Models (LLMs). They help control aspects such as creativity, coherence, repetition, and response length, ensuring that the model generates outputs tailored to specific use cases.
-- [Model Logic](https://lamatic.ai/docs/models/model-logic): Model Logic allows you to wrap and extend your model node's behavior with advanced control mechanisms like fallback, retry, conditional routing, parallel execution, and A/B testing.
+- [Benchmarks](https://lamatic.ai/docs/models/benchmark.md): Compare and evaluate LLM performance using recommended benchmarks to choose the right model for your Lamatic.ai use case.
+- [Custom Model Integration](https://lamatic.ai/docs/models/custom-model-integration.md): With Lamatic, you can define custom models per provider — this doc walks through how to add, override, and control model behavior across different AI backends.
+- [Model Config](https://lamatic.ai/docs/models/model-config.md): Model Config play a crucial role in fine-tuning the behavior of Large Language Models (LLMs). They help control aspects such as creativity, coherence, repetition, and response length, ensuring that the model generates outputs tailored to specific use cases.
+- [Model Logic](https://lamatic.ai/docs/models/model-logic.md): Model Logic allows you to wrap and extend your model node's behavior with advanced control mechanisms like fallback, retry, conditional routing, parallel execution, and A/B testing.
 
 ## Data & Context
 
-- [Memory Store](https://lamatic.ai/docs/context/memory-store): Store and retrieve long-term contextual memory for your Lamatic.ai apps, scoped to users and sessions.
-- [Vector Store](https://lamatic.ai/docs/context/vectordb): Vector Store in Lamatic Studio
-- [Mapping and Ingesting Data](https://lamatic.ai/docs/context/vectordb/adding-data): Learn how to map your data into a Weaviate schema and ingest it into Lamatic’s vector store for search and retrieval.
+- [Memory Store](https://lamatic.ai/docs/context/memory-store.md): Store and retrieve long-term contextual memory for your Lamatic.ai apps, scoped to users and sessions.
+- [Vector Store](https://lamatic.ai/docs/context/vectordb.md): Vector Store in Lamatic Studio
+- [Mapping and Ingesting Data](https://lamatic.ai/docs/context/vectordb/adding-data.md): Learn how to map your data into a Weaviate schema and ingest it into Lamatic’s vector store for search and retrieval.
 
 ## IDE
 
-- [Code IDE](https://lamatic.ai/docs/ide/code-ide): Code IDE Inside Lamatic Studio
-- [GraphQL Playgrounds IDE](https://lamatic.ai/docs/ide/graphql-ide): Lamatic Studio
-- [Prompt IDE](https://lamatic.ai/docs/ide/prompt-ide): Prompt IDE Inside lamatic.ai studio
+- [Code IDE](https://lamatic.ai/docs/ide/code-ide.md): Code IDE Inside Lamatic Studio
+- [GraphQL Playgrounds IDE](https://lamatic.ai/docs/ide/graphql-ide.md): Lamatic Studio
+- [Prompt IDE](https://lamatic.ai/docs/ide/prompt-ide.md): Prompt IDE Inside lamatic.ai studio
 
 ## MCP & Tools
 
-- [Tools](https://lamatic.ai/docs/mcp-tools/tools): A tool is a powerful feature in the Lamatic for modern AI systems that enables seamless interaction with external functions and APIs in a structured manner.
+- [Tools](https://lamatic.ai/docs/mcp-tools/tools.md): A tool is a powerful feature in the Lamatic for modern AI systems that enables seamless interaction with external functions and APIs in a structured manner.
 
 ## Testing
 
-- [Code Testing](https://lamatic.ai/docs/tests/code-testing): Testing custom code logic inside Code Nodes
-- [Flow Debugging](https://lamatic.ai/docs/tests/flow-debugging): Node-level testing and debugging in Lamatic.ai
-- [Flow Testing](https://lamatic.ai/docs/tests/flow-testing): End-to-end testing for flows in Lamatic.ai
-- [Prompt Testing](https://lamatic.ai/docs/tests/prompt-testing): Testing AI prompt outputs within flow nodes
+- [Code Testing](https://lamatic.ai/docs/tests/code-testing.md): Testing custom code logic inside Code Nodes
+- [Flow Debugging](https://lamatic.ai/docs/tests/flow-debugging.md): Node-level testing and debugging in Lamatic.ai
+- [Flow Testing](https://lamatic.ai/docs/tests/flow-testing.md): End-to-end testing for flows in Lamatic.ai
+- [Prompt Testing](https://lamatic.ai/docs/tests/prompt-testing.md): Testing AI prompt outputs within flow nodes
 
 ## Deployments
 
-- [Caching](https://lamatic.ai/docs/deployments/cache): Cache Management in Lamatic.ai
+- [Caching](https://lamatic.ai/docs/deployments/cache.md): Cache Management in Lamatic.ai
 
 ## GraphQL, Webhooks & Widgets
 
-- [GraphQL API](https://lamatic.ai/docs/interface/graphql): Deployment using GraphQL
-- [Mailhook](https://lamatic.ai/docs/interface/mailhook): Email trigger node for flows—incoming emails trigger your flow with metadata and content in the payload.
-- [Webhooks](https://lamatic.ai/docs/interface/webhooks): Set up webhook triggers in Lamatic to run flows from external events with real-time HTTP callbacks.
-- [Ask Widget](https://lamatic.ai/docs/interface/widgets/ask-widget): Embed Lamatic’s Ask Widget on your site to let users ask questions and get AI-powered answers with suggested prompts.
-- [Chat Widget](https://lamatic.ai/docs/interface/widgets/chat): Embed Lamatic’s chat widget on your website to provide AI-powered, context-aware conversations through your flows.
-- [Search Widget](https://lamatic.ai/docs/interface/widgets/search): Embed Lamatic’s search widget on your site to deliver AI-powered, context-aware search results from your content.
+- [GraphQL API](https://lamatic.ai/docs/interface/graphql.md): Deployment using GraphQL
+- [Mailhook](https://lamatic.ai/docs/interface/mailhook.md): Email trigger node for flows—incoming emails trigger your flow with metadata and content in the payload.
+- [Webhooks](https://lamatic.ai/docs/interface/webhooks.md): Set up webhook triggers in Lamatic to run flows from external events with real-time HTTP callbacks.
+- [Ask Widget](https://lamatic.ai/docs/interface/widgets/ask-widget.md): Embed Lamatic’s Ask Widget on your site to let users ask questions and get AI-powered answers with suggested prompts.
+- [Chat Widget](https://lamatic.ai/docs/interface/widgets/chat.md): Embed Lamatic’s chat widget on your website to provide AI-powered, context-aware conversations through your flows.
+- [Search Widget](https://lamatic.ai/docs/interface/widgets/search.md): Embed Lamatic’s search widget on your site to deliver AI-powered, context-aware search results from your content.
 
 ## Reports
 
-- [Langfuse Integration](https://lamatic.ai/docs/reports/langfuse-integration): Connect Langfuse to Lamatic.ai to trace, analyze, and optimize LLM calls for performance, quality, and cost.
+- [Langfuse Integration](https://lamatic.ai/docs/reports/langfuse-integration.md): Connect Langfuse to Lamatic.ai to trace, analyze, and optimize LLM calls for performance, quality, and cost.
 
 ## Api Integration
 
-- [API Keys](https://lamatic.ai/docs/api-integration/api-key): Lamatic.ai uses API keys to authenticate access. There are two types — Project API Keys for triggering deployed flows, and Enterprise API Keys for managing your organization.
-- [API Overview](https://lamatic.ai/docs/api-integration): How to integrate with Lamatic programmatically — GraphQL, REST-style usage, and when to use the SDK.
+- [API Keys](https://lamatic.ai/docs/api-integration/api-key.md): Lamatic.ai uses API keys to authenticate access. There are two types - Project API Keys for triggering deployed flows, and Enterprise API Keys for managing your organization.
+- [API Overview](https://lamatic.ai/docs/api-integration.md): How to integrate with Lamatic programmatically. GraphQL, REST-style usage, and when to use the SDK.
 
 ## Mcp
 
-- [Lamatic Docs MCP](https://lamatic.ai/docs/mcp/docs-mcp): Query Lamatic.ai documentation instantly using AI — powered by RAG and Model Context Protocol.
-- [Graph MCP](https://lamatic.ai/docs/mcp/graph-mcp): Execute your deployed Lamatic flows via AI agents using natural language.
-- [MCP Overview](https://lamatic.ai/docs/mcp): Overview of Lamatic's Model Context Protocol (MCP) offerings — MCP Node for consuming external servers, Graph MCP for exposing your flows, and Docs MCP for querying Lamatic documentation from any AI assistant.
-- [MCP Node](https://lamatic.ai/docs/mcp/mcp-node): Connect Lamatic flows to external MCP servers — securely access third-party data sources and tools through the Model Context Protocol.
+- [Lamatic Docs MCP](https://lamatic.ai/docs/mcp/docs-mcp.md): Query Lamatic.ai documentation instantly using AI, powered by RAG and Model Context Protocol.
+- [Graph MCP](https://lamatic.ai/docs/mcp/graph-mcp.md): Execute your deployed Lamatic flows via AI agents using natural language.
+- [MCP Overview](https://lamatic.ai/docs/mcp.md): Overview of Lamatic's three MCP products. MCP Node consumes external servers, Graph MCP exposes your flows, and Docs MCP answers questions about Lamatic from any AI assistant.
+- [MCP Node](https://lamatic.ai/docs/mcp/mcp-node.md): Connect Lamatic flows to external MCP servers. Securely access third-party data sources and tools through the Model Context Protocol.
 
 ## Sdk
 
-- [Go](https://lamatic.ai/docs/sdk/go): Integrate the Lamatic SDK with Go applications to execute flows and agents.
-- [SDK & Integration Guide](https://lamatic.ai/docs/sdk): A powerful tool in Lamatic for modern AI systems that enables seamless interaction with external functions and APIs in a structured manner.
-- [Integration Guide](https://lamatic.ai/docs/sdk/integration-guide): A comprehensive guide for integrating Lamatic.ai into your application using GraphQL API endpoints.
-- [Next.js](https://lamatic.ai/docs/sdk/next): Integrate the Lamatic SDK with Next.js applications to execute flows.
-- [React SDK](https://lamatic.ai/docs/sdk/react): Integrate the Lamatic SDK with React applications to execute flows.
+- [Go](https://lamatic.ai/docs/sdk/go.md): Integrate the Lamatic SDK with Go applications to execute flows and agents.
+- [SDK & Integration Guide](https://lamatic.ai/docs/sdk.md): A powerful tool in Lamatic for modern AI systems that enables seamless interaction with external functions and APIs in a structured manner.
+- [Integration Guide](https://lamatic.ai/docs/sdk/integration-guide.md): A comprehensive guide for integrating Lamatic.ai into your application using GraphQL API endpoints.
+- [Next.js](https://lamatic.ai/docs/sdk/next.md): Integrate the Lamatic SDK with Next.js applications to execute flows.
+- [React SDK](https://lamatic.ai/docs/sdk/react.md): Integrate the Lamatic SDK with React applications to execute flows.
 

--- a/public/skill.md
+++ b/public/skill.md
@@ -1,0 +1,76 @@
+---
+name: lamatic
+description: Operating guide for AI agents working with Lamatic.ai — a managed platform for building, deploying, and monitoring AI applications and agents.
+version: 1.0.0
+---
+
+# Lamatic Agent Skill
+
+This document tells AI agents (Claude, Cursor, custom assistants, etc.) how to work effectively with Lamatic.ai. It is **not** general user documentation. For that, see [llms.txt](https://lamatic.ai/llms.txt) or [the full docs](https://lamatic.ai/docs).
+
+## What Lamatic is
+
+Lamatic.ai is a managed platform for building AI-powered applications. The core unit of work is a **Flow**, a graph of connected **Nodes** that runs in order. A Flow is built in the Studio editor, deployed to an endpoint, and then called via API, SDK, CLI, or an MCP server.
+
+Key concepts:
+
+- **Flow** — a runnable graph of nodes. Triggered via API, schedule, webhook, widget, etc.
+- **Node** — a single step in a flow (AI generation, data lookup, branching logic, integration call).
+- **Agent** — a specialised AI node (Supervisor, Text, JSON, etc.) with reasoning capabilities.
+- **Context** — vector and memory stores attached to a project for RAG and stateful interactions.
+- **Project** — the deployment boundary. Each project has its own credentials, secrets, and deployment.
+- **Organization** — owns one or more projects. Org-level operations require an Enterprise API key.
+
+## How to interact with Lamatic from outside Studio
+
+Pick the right tool for the job:
+
+| Goal                                                           | Use                                                                    |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Answer a question *about* Lamatic itself                       | [Docs MCP](https://docmcp.lamatic.ai/api/mcp) — hosted, no auth needed |
+| Run a deployed flow from natural language                      | [Graph MCP](https://lamatic.ai/docs/mcp/graph-mcp)                     |
+| Manage projects / flows / credentials programmatically         | [CLI](https://lamatic.ai/docs/cli) or Enterprise API                   |
+| Call a flow from application code                              | [SDK](https://lamatic.ai/docs/sdk) (JS/TS, React, Next.js, Go)         |
+| Make raw GraphQL requests                                      | [API Integration](https://lamatic.ai/docs/api-integration)             |
+| Connect Lamatic flows to external MCP servers                  | [MCP Node](https://lamatic.ai/docs/mcp/mcp-node)                       |
+
+## Authentication
+
+Two key types:
+
+- **Project API key** — scoped to one project. Used to trigger flows from an app. Header: `Authorization: Bearer <key>` plus `x-project-id: <project-id>`.
+- **Enterprise API key** — scoped to the whole organization (prefix `lt-org-...`). Used for managing org-level resources. Required by the CLI, Graph MCP, and Dev MCP.
+
+Never log, print, or commit either key. If a user pastes one in chat, treat it as sensitive.
+
+## Endpoints worth knowing
+
+- `https://lamatic.ai/llms.txt` — curated documentation index, markdown links.
+- `https://lamatic.ai/llms-full.txt` — full concatenated docs in one file.
+- `https://lamatic.ai/<doc-url>.md` — markdown version of any doc page (append `.md`).
+- `https://docmcp.lamatic.ai/api/mcp` — Docs MCP server (free, no auth).
+- `https://<project>.lamatic.dev/graphql` — per-project GraphQL endpoint for running flows.
+
+## Recommended behaviours
+
+- **Prefer the Docs MCP** for any "how do I…" or "what does X mean" question. It answers from the live indexed docs.
+- **Prefer `.md` URLs** when fetching docs pages programmatically; you get clean markdown instead of rendered HTML.
+- **Use the CLI** for repeatable org actions (deploy, create flow, update credentials). Avoid scripting raw GraphQL for management tasks unless the CLI doesn't cover it.
+- **Confirm destructive operations** (deleting a project, deleting a flow, deploying to production) with the user before running them.
+- **Stay scoped to a project** unless the user explicitly asks for org-level work. Most flow operations require only a Project API key.
+- **Quote field names verbatim** from the docs when constructing payloads. Node parameter names use `snake_case` in the low-code config (e.g. `recipient_email`, `is_html`, `add_label_ids`).
+
+## What to avoid
+
+- Inventing endpoint paths, header names, or field names. If unsure, query the Docs MCP or read the relevant `.md` page.
+- Running `lamatic project delete` or `dev_delete_project` without explicit user confirmation.
+- Calling org-level endpoints with a Project API key (they will fail with an auth error).
+- Treating output from the Docs MCP as authoritative for *your own* private flows — it indexes public docs only.
+
+## Source of truth
+
+- Public docs: [lamatic.ai/docs](https://lamatic.ai/docs)
+- Index for agents: [lamatic.ai/llms.txt](https://lamatic.ai/llms.txt)
+- Status / changelog: [lamatic.ai/changelog](https://lamatic.ai/changelog)
+
+If something on this page contradicts the latest docs, the docs win.

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -78,7 +78,9 @@ function fileToUrl(filePath) {
     .replace(/\\/g, "/")
     .replace(/\.mdx$/, "")
     .replace(/\/index$/, "");
-  return `${SITE_URL}/${rel}`;
+  // Append .md so agents fetching this link receive markdown
+  // (next.config.mjs rewrites /:path*.md to /api/md-src/:path*).
+  return `${SITE_URL}/${rel}.md`;
 }
 
 /** Map a docs file to the top-level section it lives under. */

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -119,6 +119,12 @@ const config: DocsThemeConfig = {
 
     return (
       <>
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href="/llms.txt"
+          title="llms.txt"
+        />
         <meta name="theme-color" content="#000" />
         <meta property="og:url" content={url} />
         <meta httpEquiv="Content-Language" content="en" />


### PR DESCRIPTION
Fixed minor issues, added skill.md, and updated llm files with .md support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation Updates & Markdown Format Support

- **Added new `skill.md`** - Agent skill guidance document for working with Lamatic.ai (76 lines)
- **Updated LLM integration** - Modified rewrite rules to exclude `skill.md` and `/.well-known` paths
- **Markdown format support** - Updated `generate-llms-txt.js` to append `.md` extension to documentation links
- **API enhancement** - API endpoint now prepends "llms.txt" directive to markdown responses
- **Documentation refresh** - Updated `llms.txt` and `llms-full.txt` with new URLs, headings ("Lamatic CLI (Beta)", "(Beta)" labels), and restructured content across widgets, MCP, SDK, and node documentation
- **MCP discovery** - Added `public/.well-known/mcp.json` with MCP server discovery configuration (`lamatic-docs`, `lamatic-graph`)
- **Content improvements** - Rewrote MCP index page with refined descriptions, added structured guidance (tables, configuration), expanded widget documentation, and improved cross-linking
- **Theme updates** - Added alternate link for markdown content type in theme configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->