### PR TITLE
Change redirect URL from get.lamatic.ai to landing.lamatic.ai

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -708,7 +708,7 @@ const rewrites = [
   ["/robots.txt", "/public/robots.txt"],
     [
       "/:path((?!docs|blog|guides|integrations|agentkits|templates|company|_next|public|assets|images|api|robots.txt|sitemap-0.xml|llms.txt|llms-full.txt|skill.md|\\.well-known|ambassadors).*)",
-      "https://get.lamatic.ai/:path*",
+      "https://landing.lamatic.ai/:path*",
     ],
 ];
 export default withBundleAnalyzer(nextraConfig);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated the catch-all rewrite for non-docs routes to use `https://landing.lamatic.ai/:path*`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->