### PR TITLE
docs: fix pnpm setup instructions and add Changelog link to footer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,8 @@ Thank you for your interest in improving Lamatic Docs! Follow the steps below to
 ## 4) Preview/test locally (optional but recommended)
 
 ```bash
-npm install
-npm run dev
+pnpm install
+pnpm dev
 ```
 
 Open the printed localhost URL to verify your changes look correct. Stop the dev server when done.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ To run the lamatic.ai documentation locally, you need:
 ### Local Setup
 
 1. Clone the repository
-2. Run `npm install` to install dependencies
-3. Run `npm run dev` to start the development server on localhost:3333
+2. Run `pnpm install` to install dependencies
+3. Run `pnpm dev` to start the development server on localhost:3333
 4. Visit http://localhost:3333/docs to view the documentation
 
 For more detailed instructions, see our [contributing guide](https://lamatic.ai/docs/contributing).

--- a/components/DocsFooter.tsx
+++ b/components/DocsFooter.tsx
@@ -8,6 +8,7 @@ const legalLinks = [
 ];
 
 const companyLinks = [
+  { label: "Changelog", href: "https://product.lamatic.ai/changelog" },
   { label: "Community and Support", href: "/docs/slack" },
   { label: "Partners", href: "/company/partners" },
   { label: "Brandkit", href: "/company/brandkit" },

--- a/pages/docs/contributing.mdx
+++ b/pages/docs/contributing.mdx
@@ -82,11 +82,11 @@ When writing or editing docs, follow these principles so the docs stay clear and
 
     - Install the necessary dependencies:
        ```
-       npm install
+       pnpm install
        ```
     - Start the development server:
        ```
-       npm run dev
+       pnpm dev
        ```
     - Open your browser and go to `http://localhost:3333/docs` to see your changes in real-time.
 


### PR DESCRIPTION
## What changed and why

Two small fixes for existing issues:

### 1. Fix npm instructions across the repo (Fixes #560)
The docs suggested `npm install` / `npm run dev`, but the repo actually uses pnpm (`pnpm-lock.yaml` + `packageManager` field in package.json), so following them as-is fails. Updated the commands to `pnpm install` / `pnpm dev` in all three places where they appeared:

- `CONTRIBUTING.md`
- `README.md`
- `pages/docs/contributing.mdx`

### 2. Add Changelog link to the footer (Fixes #478)
The footer only had Company / Legal / Security groups, with no Changelog link. Added a **Changelog** entry to the Company links in `components/DocsFooter.tsx`. It points to `https://product.lamatic.ai/changelog` — the same URL the navbar already uses for Changelog, so I kept it consistent.

## How tested
- Confirmed pnpm is the package manager from the lockfile and `packageManager` field before changing the commands.
- Checked that the changelog URL used in the navbar works and reused it for the footer link.
- Docs-only change (markdown + one footer link); no build logic touched.